### PR TITLE
kappa-to-plv

### DIFF
--- a/examples/select_kappa.py
+++ b/examples/select_kappa.py
@@ -1,0 +1,30 @@
+import numpy as np
+from harmoni.extratools import compute_plv
+from matplotlib import pyplot as plt
+from meegsim.coupling import ppc_von_mises
+from meegsim.utils import get_sfreq
+
+
+lenghts = [.5, 1, 10, 60]
+n_kappas = 100
+n_runs = 1000
+kappas = np.logspace(-5, 3, n_kappas)
+fs = 1000
+for length in lenghts:
+    print(length)
+    times = np.arange(0, length, 1 / fs)
+    waveform = np.sin(2 * np.pi * 10 * times)
+    phase_lag = 0
+    plv = np.zeros((n_runs, n_kappas))
+    for run in range(n_runs):
+        for ikappa, kappa in enumerate(kappas):
+            result = ppc_von_mises(waveform, get_sfreq(times), phase_lag, kappa=kappa)
+            cplv = compute_plv(waveform, result, m=1, n=1, plv_type='complex')
+            plv[run, ikappa] = np.abs(cplv)[0][0]
+
+    plt.plot(np.log10(kappas), plv.T, c='grey')
+    plt.plot(np.log10(kappas), np.mean(plv, axis=0), c='k', linewidth=3)
+    plt.xlabel('Kappa, logscale')
+    plt.ylabel('plv')
+    plt.savefig('kappa-to-plv_length' + str(length) + 'sec.png')
+    plt.close()


### PR DESCRIPTION
Code provides the intuition on how kappa changes plv between two signals of various lenghts.
The code returns the following figures:

1. _Length of simulated signal = 0.5 sec_
![kappa-to-plv_length0 5sec](https://github.com/user-attachments/assets/77f56da4-e361-4c62-bd55-da79f152ec62)

2. _Length of simulated signal = 1 sec_
![kappa-to-plv_length1sec](https://github.com/user-attachments/assets/53cbedc5-fcb6-471d-9519-3c0a95f4320c)

3. _Length of simulated signal = 10 sec_
![kappa-to-plv_length10sec](https://github.com/user-attachments/assets/20a224f2-7f1c-42eb-b723-f6e3f906c306)

4. _Length of simulated signal = 60 sec_
![kappa-to-plv_length60sec](https://github.com/user-attachments/assets/6e6fbeed-3a83-44ed-bedd-606cdc2ece7b)
