### PR TITLE
ENH: sensor space noise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Version 0.0.2 (Unreleased)
+
+### Added
+
+- A desired level of white noise can be added in sensor space to model measurement
+noise ([#58](https://github.com/ctrltz/meegsim/pull/58))
+
 ## Version 0.0.1 (2024-10-31)
 
 ### Added

--- a/examples/dummy.py
+++ b/examples/dummy.py
@@ -6,7 +6,6 @@ import json
 import mne
 import numpy as np
 
-from harmoni.extratools import compute_plv
 from pathlib import Path
 
 from meegsim.coupling import ppc_von_mises

--- a/examples/dummy.py
+++ b/examples/dummy.py
@@ -44,12 +44,19 @@ fwd = mne.pick_channels_forward(fwd, info.ch_names, ordered=True)
 
 sim = SourceSimulator(src)
 
+sim.add_noise_sources(
+    location=select_random,
+    location_params=dict(n=100)
+)
+
 # Select some vertices randomly
 sim.add_point_sources(
     location=select_random,
     waveform=narrowband_oscillation,
+    snr=1,
     location_params=dict(n=3),
     waveform_params=dict(fmin=8, fmax=12),
+    snr_params=dict(fmin=8, fmax=12),
     names=['s1', 's2', 's3']
 )
 
@@ -63,12 +70,7 @@ print(sim._coupling_graph)
 print(sim._coupling_graph.edges(data=True))
 
 sc = sim.simulate(sfreq, duration, fwd=fwd, random_state=seed)
-raw = sc.to_raw(fwd, info)
-
-source_data = np.vstack([s.waveform for s in sc._sources.values()])
-
-print('PLV:', compute_plv(source_data, source_data, n=1, m=1))
-print('iPLV:', compute_plv(source_data, source_data, n=1, m=1, plv_type='imag'))
+raw = sc.to_raw(fwd, info, sensor_noise_factor=0.01)
 
 spec = raw.compute_psd(n_fft=sfreq, n_overlap=sfreq//2, n_per_seg=sfreq)
 spec.plot(sphere='eeglab')

--- a/examples/sensor_space_noise.py
+++ b/examples/sensor_space_noise.py
@@ -55,7 +55,7 @@ sim.add_noise_sources(
 sc = sim.simulate(sfreq, duration, fwd=fwd, random_state=seed)
 raw = sc.to_raw(fwd, info)
 
-noise_levels = [0, 0.05, 0.1, 0.25, 0.5, 0.95]
+noise_levels = [0, 0.05, 0.1, 0.25, 0.5, 1]
 n_levels = len(noise_levels)
 fig, axes = plt.subplots(ncols=n_levels, figsize=(3 * n_levels, 3))
 

--- a/examples/sensor_space_noise.py
+++ b/examples/sensor_space_noise.py
@@ -2,16 +2,14 @@
 Testing the sensor space noise
 """
 
-import numpy as np
 import mne
 import matplotlib.pyplot as plt
-import seaborn as sns
 
 from pathlib import Path
 
 from meegsim.location import select_random
 from meegsim.simulate import SourceSimulator
-from meegsim.waveform import narrowband_oscillation, white_noise
+from meegsim.waveform import narrowband_oscillation
 
 
 # Load the head model
@@ -57,14 +55,14 @@ sim.add_noise_sources(
 sc = sim.simulate(sfreq, duration, fwd=fwd, random_state=seed)
 raw = sc.to_raw(fwd, info)
 
-noise_levels = [0, 0.25, 0.5, 0.75, 1]
+noise_levels = [0, 0.05, 0.1, 0.25, 0.5, 0.95]
 n_levels = len(noise_levels)
 fig, axes = plt.subplots(ncols=n_levels, figsize=(3 * n_levels, 3))
 
 for i_level, noise_level in enumerate(noise_levels):
     raw = sc.to_raw(fwd, info, sensor_noise_level=noise_level)
 
-    spec = raw.compute_psd(n_fft=sfreq, 
+    spec = raw.compute_psd(fmax=60, n_fft=sfreq, 
                            n_overlap=sfreq//2, n_per_seg=sfreq)
     spec.plot(axes=axes[i_level], amplitude=False, sphere='eeglab')
     

--- a/examples/sensor_space_noise.py
+++ b/examples/sensor_space_noise.py
@@ -1,22 +1,17 @@
 """
-Testing the configuration structure
+Testing the sensor space noise
 """
 
-import json
-import mne
 import numpy as np
+import mne
+import matplotlib.pyplot as plt
+import seaborn as sns
 
-from harmoni.extratools import compute_plv
 from pathlib import Path
 
-from meegsim.coupling import ppc_von_mises
 from meegsim.location import select_random
 from meegsim.simulate import SourceSimulator
-from meegsim.waveform import narrowband_oscillation
-
-
-def to_json(sources):
-    return json.dumps({k: str(s) for k, s in sources.items()}, indent=4)
+from meegsim.waveform import narrowband_oscillation, white_noise
 
 
 # Load the head model
@@ -30,7 +25,6 @@ fwd = mne.read_forward_solution(fwd_path)
 sfreq = 250
 duration = 60
 seed = 123
-target_snr = 20
 
 # Channel info
 montage = mne.channels.make_standard_montage('standard_1020')
@@ -44,34 +38,38 @@ fwd = mne.pick_channels_forward(fwd, info.ch_names, ordered=True)
 
 sim = SourceSimulator(src)
 
+# Select some vertices randomly
+sim.add_point_sources(
+    location=select_random,
+    waveform=narrowband_oscillation,
+    location_params=dict(n=3),
+    waveform_params=dict(fmin=8, fmax=12),
+    snr=2.5,
+    snr_params=dict(fmin=8, fmax=12),
+    names=['s1', 's2', 's3']
+)
+
 sim.add_noise_sources(
     location=select_random,
     location_params=dict(n=10)
 )
 
-# Select some vertices randomly
-sim.add_point_sources(
-    location=select_random,
-    waveform=narrowband_oscillation,
-    snr=1,
-    location_params=dict(n=3),
-    waveform_params=dict(fmin=8, fmax=12),
-    snr_params=dict(fmin=8, fmax=12),
-    names=['s1', 's2', 's3']
-)
-
-# Set coupling
-sim.set_coupling(coupling={
-    ('s1', 's2'): dict(kappa=1, phase_lag=np.pi/3),
-    ('s2', 's3'): dict(kappa=10, phase_lag=-np.pi/2)
-}, method=ppc_von_mises, fmin=8, fmax=12)
-
-print(sim._coupling_graph)
-print(sim._coupling_graph.edges(data=True))
-
 sc = sim.simulate(sfreq, duration, fwd=fwd, random_state=seed)
-raw = sc.to_raw(fwd, info, sensor_noise_level=0.1)
+raw = sc.to_raw(fwd, info)
 
-spec = raw.compute_psd(n_fft=sfreq, n_overlap=sfreq//2, n_per_seg=sfreq)
-spec.plot(sphere='eeglab')
-input('Press any key to continue')
+noise_levels = [0, 0.25, 0.5, 0.75, 1]
+n_levels = len(noise_levels)
+fig, axes = plt.subplots(ncols=n_levels, figsize=(3 * n_levels, 3))
+
+for i_level, noise_level in enumerate(noise_levels):
+    raw = sc.to_raw(fwd, info, sensor_noise_level=noise_level)
+
+    spec = raw.compute_psd(n_fft=sfreq, 
+                           n_overlap=sfreq//2, n_per_seg=sfreq)
+    spec.plot(axes=axes[i_level], amplitude=False, sphere='eeglab')
+    
+    axes[i_level].set_title(f'{noise_level=}')
+    axes[i_level].set_xlabel('Frequency (Hz)')
+
+fig.tight_layout()
+plt.show(block=True)

--- a/src/meegsim/_check.py
+++ b/src/meegsim/_check.py
@@ -92,7 +92,7 @@ def check_vertices_list_of_tuples(vertices):
 
     if not isinstance(vertices, (list, tuple)):
         raise ValueError(
-            f"Expected vertices to be a list or a tuple, " f" got {type(vertices)}"
+            f"Expected vertices to be a list or a tuple, got {type(vertices)}"
         )
 
     for i, el in enumerate(vertices):

--- a/src/meegsim/configuration.py
+++ b/src/meegsim/configuration.py
@@ -78,7 +78,8 @@ class SourceConfiguration:
         sensor_noise_level : float, optional
             The desired level of sensor-space noise between 0 and 1. For example,
             if 0.1 is specified, 10% of total sensor-space power will stem from
-            white noise with an identity covariance matrix. By default,
+            white noise with an identity covariance matrix, while 90% will be
+            explained by source activity projected to sensor space. By default,
             no sensor space noise is added. See Notes for more details.
 
         Returns

--- a/src/meegsim/configuration.py
+++ b/src/meegsim/configuration.py
@@ -82,13 +82,33 @@ class SourceConfiguration:
             The source activity is scaled by this factor before projecting to
             sensor space. By default, the scaling factor is equal to :math:`10^{-6}`.
         sensor_noise_level : float, optional
-            The level of sensor space noise. TODO: precise description.
-            By default, no sensor space noise is added.
+            The desired ratio of the power of sensor space noise (modeled with 
+            white noise that has an identity covariance matrix) and the total power,
+            adjusted for the broadband data. By default, no sensor 
+            space noise is added. See Notes for more details.
             
         Returns
         -------
         raw : Raw
             The simulated sensor space data.
+
+        Notes
+        -----
+        The adjustment of sensor space noise is performed as follows:
+
+        1. The sensor space noise is scaled to equalize the mean sensor-space variance 
+        of noise and brain activity.
+
+        2. The brain activity and noise are mixed to achieve the desired level of 
+        sensor space noise (denoted by :math:`\\gamma` below):
+
+        .. math::
+
+            \\begin{eqnarray}
+                y & = \\sqrt{1 - \\gamma} \\cdot y_{brain} + \\sqrt{\\gamma} \\cdot y_{noise} \\\\
+                \\\\
+                P_{total} & = (1 - \\gamma) \\cdot P_{brain} + \\gamma \\cdot P_{noise}
+            \\end{eqnarray}
         """
 
         # Multiply the combined stc by the scaling factor

--- a/src/meegsim/configuration.py
+++ b/src/meegsim/configuration.py
@@ -81,10 +81,11 @@ class SourceConfiguration:
             The source activity is scaled by this factor before projecting to
             sensor space. By default, the scaling factor is equal to :math:`10^{-6}`.
         sensor_noise_level : float, optional
-            The desired ratio of the power of sensor space noise (modeled with 
-            white noise that has an identity covariance matrix) and the total power,
-            adjusted for the broadband data. By default, no sensor 
-            space noise is added. See Notes for more details.
+            The desired level of sensor-space noise. The noise is modeled with 
+            white noise that has an identity covariance matrix. For example, if 
+            0.1 is specified, 10% of total sensor-space power will stem from the 
+            sensor-space noise. By default, no sensor space noise is added. 
+            See Notes for more details.
             
         Returns
         -------
@@ -96,7 +97,7 @@ class SourceConfiguration:
         The adjustment of sensor space noise is performed as follows:
 
         1. The sensor space noise is scaled to equalize the mean sensor-space variance 
-        of noise and brain activity.
+        of broadband noise and brain activity.
 
         2. The brain activity and noise are mixed to achieve the desired level of 
         sensor space noise (denoted by :math:`\\gamma` below):

--- a/src/meegsim/configuration.py
+++ b/src/meegsim/configuration.py
@@ -1,6 +1,7 @@
 import numpy as np
 import mne
 
+from .snr import _adjust_sensor_noise
 from .sources import _combine_sources_into_stc
 from .waveform import white_noise
 
@@ -61,7 +62,13 @@ class SourceConfiguration:
 
         return _combine_sources_into_stc(all_sources, self.src, self.tstep)
 
-    def to_raw(self, fwd, info, sensor_noise_factor=None, scaling_factor=1e-6):
+    def to_raw(
+        self, 
+        fwd, 
+        info, 
+        scaling_factor=1e-6,
+        sensor_noise_level=None
+    ):
         """
         Project the activity of all simulated sources to sensor space.
 
@@ -71,12 +78,12 @@ class SourceConfiguration:
             The forward model.
         info : Info
             The info structure that describes the channel layout.
-        sensor_noise_factor : float, optional
-            The level of sensor space noise. TODO: precise description.
-            By default, no sensor space noise is added.
         scaling_factor : float, optional
             The source activity is scaled by this factor before projecting to
             sensor space. By default, the scaling factor is equal to :math:`10^{-6}`.
+        sensor_noise_level : float, optional
+            The level of sensor space noise. TODO: precise description.
+            By default, no sensor space noise is added.
             
         Returns
         -------
@@ -91,10 +98,9 @@ class SourceConfiguration:
         raw = mne.apply_forward_raw(fwd, stc_combined, info)
 
         # Add sensor space noise if needed  
-        if sensor_noise_factor:            
+        if sensor_noise_level:            
             noise = white_noise(info["nchan"], self.times,
                                 random_state=self.random_state)
-            raw._data = (1 - sensor_noise_factor) * raw._data + \
-                sensor_noise_factor * noise
+            raw = _adjust_sensor_noise(raw, noise, sensor_noise_level)
 
         return raw

--- a/src/meegsim/configuration.py
+++ b/src/meegsim/configuration.py
@@ -1,9 +1,8 @@
 import numpy as np
 import mne
 
-from .snr import _adjust_sensor_noise
+from .sensor_noise import _adjust_sensor_noise, _prepare_sensor_noise
 from .sources import _combine_sources_into_stc
-from .waveform import white_noise
 
 
 class SourceConfiguration:
@@ -119,8 +118,7 @@ class SourceConfiguration:
 
         # Add sensor space noise if needed  
         if sensor_noise_level:            
-            noise = white_noise(info["nchan"], self.times,
-                                random_state=self.random_state)
+            noise = _prepare_sensor_noise(raw, self.times, self.random_state)
             raw = _adjust_sensor_noise(raw, noise, sensor_noise_level)
 
         return raw

--- a/src/meegsim/configuration.py
+++ b/src/meegsim/configuration.py
@@ -78,9 +78,9 @@ class SourceConfiguration:
         sensor_noise_level : float, optional
             The desired level of sensor-space noise between 0 and 1. For example,
             if 0.1 is specified, 10% of total sensor-space power will stem from
-            white noise with an identity covariance matrix, while 90% will be
-            explained by source activity projected to sensor space. By default,
-            no sensor space noise is added. See Notes for more details.
+            white noise with an identity covariance matrix, while the remaining 90%
+            of power will be explained by source activity projected to sensor space.
+            By default, no sensor space noise is added. See Notes for more details.
 
         Returns
         -------

--- a/src/meegsim/sensor_noise.py
+++ b/src/meegsim/sensor_noise.py
@@ -1,0 +1,40 @@
+import numpy as np
+
+from .snr import amplitude_adjustment_factor
+from .waveform import white_noise
+
+
+def _prepare_sensor_noise(raw, times, random_state):
+    n_chans = len(raw.ch_names)
+    noise = white_noise(n_chans, times,
+                        random_state=random_state)
+    
+    # Scale the noise to equalize the mean sensor-space variance of 
+    # brain activity and sensor noise
+    signal = raw.get_data()
+    signal_var = np.trace(signal @ signal.T)
+    noise_var = np.trace(noise @ noise.T)
+    factor = amplitude_adjustment_factor(signal_var, noise_var, target_snr=1)
+
+    # Dividing here since we are adjusting noise, not the signal
+    noise /= factor
+
+    return noise
+
+
+def _adjustment_factors(noise_level):
+    return np.sqrt(1 - noise_level), np.sqrt(noise_level)
+
+
+def _adjust_sensor_noise(raw, noise, sensor_noise_level):
+    """
+    Mix brain activity and sensor noise together
+    sensor_noise_level = power_sensor_noise / power_total
+    """
+
+    factor_signal, factor_noise = _adjustment_factors(sensor_noise_level)
+    
+    raw_mixed = raw.copy()
+    raw_mixed._data = factor_signal * raw._data + factor_noise * noise
+
+    return raw_mixed

--- a/src/meegsim/snr.py
+++ b/src/meegsim/snr.py
@@ -135,3 +135,30 @@ def _adjust_snr(src, fwd, tstep, sources, source_groups, noise_sources):
             s.waveform *= factor
 
     return sources
+
+
+def _adjust_sensor_noise(raw, noise, sensor_noise_level):
+    # Scale the noise to equalize the mean sensor-space variance of 
+    # brain activity and sensor noise
+    signal = raw.get_data()
+    signal_var = np.trace(signal @ signal.T)
+    noise_var = np.trace(noise @ noise.T)
+    factor = amplitude_adjustment_factor(signal_var, noise_var, target_snr=1)
+
+    # Dividing here since we are adjusting noise, not the signal
+    noise /= factor
+
+    print(f'Signal variance: {signal_var}')
+    print(f'Noise variance (original): {noise_var}')
+    print(f'Amplitude adjustment factor: {factor}')
+    print(f'Noise variance (after scaling): {np.trace(noise @ noise.T)}')
+
+    # Mix brain activity and sensor noise together
+    # sensor_noise_level = power_sensor_noise / power_total
+    factor_raw = np.sqrt(1 - sensor_noise_level)
+    factor_noise = np.sqrt(sensor_noise_level)
+    raw_mixed = raw.copy()
+    print(f'{sensor_noise_level=}, {factor_raw=}, {factor_noise=}')
+    raw_mixed._data = factor_raw * raw._data + factor_noise * noise
+
+    return raw_mixed

--- a/src/meegsim/snr.py
+++ b/src/meegsim/snr.py
@@ -148,17 +148,12 @@ def _adjust_sensor_noise(raw, noise, sensor_noise_level):
     # Dividing here since we are adjusting noise, not the signal
     noise /= factor
 
-    print(f'Signal variance: {signal_var}')
-    print(f'Noise variance (original): {noise_var}')
-    print(f'Amplitude adjustment factor: {factor}')
-    print(f'Noise variance (after scaling): {np.trace(noise @ noise.T)}')
-
     # Mix brain activity and sensor noise together
     # sensor_noise_level = power_sensor_noise / power_total
     factor_raw = np.sqrt(1 - sensor_noise_level)
     factor_noise = np.sqrt(sensor_noise_level)
+    
     raw_mixed = raw.copy()
-    print(f'{sensor_noise_level=}, {factor_raw=}, {factor_noise=}')
     raw_mixed._data = factor_raw * raw._data + factor_noise * noise
 
     return raw_mixed

--- a/src/meegsim/snr.py
+++ b/src/meegsim/snr.py
@@ -135,25 +135,3 @@ def _adjust_snr(src, fwd, tstep, sources, source_groups, noise_sources):
             s.waveform *= factor
 
     return sources
-
-
-def _adjust_sensor_noise(raw, noise, sensor_noise_level):
-    # Scale the noise to equalize the mean sensor-space variance of 
-    # brain activity and sensor noise
-    signal = raw.get_data()
-    signal_var = np.trace(signal @ signal.T)
-    noise_var = np.trace(noise @ noise.T)
-    factor = amplitude_adjustment_factor(signal_var, noise_var, target_snr=1)
-
-    # Dividing here since we are adjusting noise, not the signal
-    noise /= factor
-
-    # Mix brain activity and sensor noise together
-    # sensor_noise_level = power_sensor_noise / power_total
-    factor_raw = np.sqrt(1 - sensor_noise_level)
-    factor_noise = np.sqrt(sensor_noise_level)
-    
-    raw_mixed = raw.copy()
-    raw_mixed._data = factor_raw * raw._data + factor_noise * noise
-
-    return raw_mixed

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -5,37 +5,69 @@ import warnings
 
 from functools import partial
 from meegsim._check import (
-    check_callable, check_vertices_list_of_tuples, check_vertices_in_src,
-    check_location, check_waveform, check_names, check_snr, check_snr_params,
-    check_if_source_exists, check_coupling, check_coupling_params
+    check_callable,
+    check_vertices_list_of_tuples,
+    check_vertices_in_src,
+    check_location,
+    check_waveform,
+    check_names,
+    check_snr,
+    check_snr_params,
+    check_if_source_exists,
+    check_coupling,
+    check_coupling_params,
+    check_numeric,
 )
 
 from utils.prepare import prepare_source_space
 
 
+def test_check_numeric_should_pass():
+    check_numeric("var", None)
+    check_numeric("var", 0)
+    check_numeric("var", 0, [0, 1])
+    check_numeric("var", 1, [0, 1])
+
+
+def test_check_numeric_bad_type():
+    with pytest.raises(ValueError, match="Expected var to be a float number"):
+        check_numeric("var", None, allow_none=False)
+
+    with pytest.raises(ValueError, match="Expected var to be a float number"):
+        check_numeric("var", "abcd")
+
+
+def test_check_numeric_out_of_bounds():
+    with pytest.raises(ValueError, match="Expected var to be 0 or greater"):
+        check_numeric("var", -1, bounds=[0, 2])
+
+    with pytest.raises(ValueError, match="Expected var to be 2 or lower"):
+        check_numeric("var", 5, bounds=[0, 2])
+
+
 def test_check_callable():
     def good_callable(*args, **kwargs):
-        args_dict = {f'arg{i}': arg for i, arg in enumerate(args)}
+        args_dict = {f"arg{i}": arg for i, arg in enumerate(args)}
         args_dict.update(kwargs)
 
         return args_dict
-    
-    result = check_callable('good', good_callable, 'arg', kwarg='kwarg')
-    
+
+    result = check_callable("good", good_callable, "arg", kwarg="kwarg")
+
     # Check that all arguments were passed correctly
-    assert result['arg0'] == 'arg'
-    assert result['kwarg'] == 'kwarg'
+    assert result["arg0"] == "arg"
+    assert result["kwarg"] == "kwarg"
 
     # Always calling with random_state of 0
-    assert result['random_state'] == 0
+    assert result["random_state"] == 0
 
 
 def test_check_callable_raises():
     def bad_callable(*args, **kwargs):
         raise ValueError("original error message")
-    
+
     with pytest.raises(ValueError, match="original error message"):
-        check_callable('bad', bad_callable, 'arg', kwarg='kwarg')
+        check_callable("bad", bad_callable, "arg", kwarg="kwarg")
 
 
 def test_check_vertices_list_of_tuples():
@@ -44,20 +76,21 @@ def test_check_vertices_list_of_tuples():
 
 def test_check_vertices_list_of_tuples_raises():
     with pytest.raises(ValueError, match="vertices to be a list or a tuple"):
-        check_vertices_list_of_tuples('aaa')
+        check_vertices_list_of_tuples("aaa")
 
-    with pytest.raises(ValueError, match="to be a list or a tuple, does not hold for element 1"):
+    with pytest.raises(
+        ValueError, match="to be a list or a tuple, does not hold for element 1"
+    ):
         check_vertices_list_of_tuples([(0, 1), 1])
 
-    with pytest.raises(ValueError, match="contain 2 values, does not hold for element \(1, 2, 3\)"):
+    with pytest.raises(
+        ValueError, match="contain 2 values, does not hold for element \(1, 2, 3\)"
+    ):
         check_vertices_list_of_tuples([(0, 1), (0, 2), (1, 2, 3)])
 
 
 def test_check_vertices_in_src():
-    src = prepare_source_space(
-        types=['surf', 'surf'],
-        vertices=[[0, 1], [0, 1]]
-    )
+    src = prepare_source_space(types=["surf", "surf"], vertices=[[0, 1], [0, 1]])
 
     # should pass for point sources
     check_vertices_in_src([(0, 0), (0, 1), (1, 0), (1, 1)], src)
@@ -67,85 +100,69 @@ def test_check_vertices_in_src():
 
 
 def test_check_vertices_in_src_raises():
-    src = prepare_source_space(
-        types=['surf', 'surf'],
-        vertices=[[0, 1], [0, 1]]
-    )
+    src = prepare_source_space(types=["surf", "surf"], vertices=[[0, 1], [0, 1]])
 
-    with pytest.raises(ValueError, match='Vertex \(2, 0\) belongs to'):
+    with pytest.raises(ValueError, match="Vertex \(2, 0\) belongs to"):
         check_vertices_in_src([(0, 0), (1, 0), (2, 0)], src)
 
-    with pytest.raises(ValueError, match='Vertex 2 is not present'):
+    with pytest.raises(ValueError, match="Vertex 2 is not present"):
         check_vertices_in_src([(0, 0), (0, 1), (0, 2)], src)
 
-    with pytest.raises(ValueError, match='Vertex 2 is not present'):
+    with pytest.raises(ValueError, match="Vertex 2 is not present"):
         check_vertices_in_src([(0, [0, 1, 2])], src)
 
-    with pytest.raises(ValueError, match='Vertices 2, 3 are not present'):
+    with pytest.raises(ValueError, match="Vertices 2, 3 are not present"):
         check_vertices_in_src([(0, [0, 2, 3])], src)
 
 
 def test_check_location_using_arrays():
     location = [(0, 0), (1, 1)]
-    src = prepare_source_space(
-        types=['surf', 'surf'],
-        vertices=[[0, 1], [0, 1]]
-    )
+    src = prepare_source_space(types=["surf", "surf"], vertices=[[0, 1], [0, 1]])
     checked, n_vertices = check_location(
-        location, 
-        dict(pick=1),     # should be ignored
-        src
+        location,
+        dict(pick=1),  # should be ignored
+        src,
     )
 
-    assert checked == location, \
-        "The provided value for location was changed"
+    assert checked == location, "The provided value for location was changed"
     assert n_vertices == 2, "Wrong number of vertices"
-    
+
 
 def test_check_location_using_callables():
     def location_fun(src, pick=0, random_state=None):
         # pick the desired vertex in each source space
-        return [
-            (src_idx, s['vertno'][pick]) 
-            for src_idx, s in enumerate(src)
-        ]
-    
-    src = prepare_source_space(
-        types=['surf', 'surf'],
-        vertices=[[0, 1], [0, 1]]
-    )
-    checked, n_vertices = check_location(
-        location_fun, 
-        dict(pick=1),
-        src
-    )
+        return [(src_idx, s["vertno"][pick]) for src_idx, s in enumerate(src)]
 
-    assert isinstance(checked, partial), \
-        "Expected the location function to be converted to a partial object"
-    assert checked.keywords['pick'] == 1, \
-        "The provided value of the keyword argument was changed"
+    src = prepare_source_space(types=["surf", "surf"], vertices=[[0, 1], [0, 1]])
+    checked, n_vertices = check_location(location_fun, dict(pick=1), src)
+
+    assert isinstance(
+        checked, partial
+    ), "Expected the location function to be converted to a partial object"
+    assert (
+        checked.keywords["pick"] == 1
+    ), "The provided value of the keyword argument was changed"
     assert n_vertices == 2, "Wrong number of vertices"
 
 
 def test_check_waveform_with_arrays():
     waveform = np.ones((2, 100))
     checked = check_waveform(
-        waveform, 
-        dict(value=1),     # should be ignored
-        n_sources=2
+        waveform,
+        dict(value=1),  # should be ignored
+        n_sources=2,
     )
 
-    assert np.array_equal(checked, waveform), \
-        "The provided waveform was changed"
-    
+    assert np.array_equal(checked, waveform), "The provided waveform was changed"
+
 
 def test_check_waveform_array_bad_shape_raises():
     waveform = np.ones((5, 100))
     with pytest.raises(ValueError, match="number of sources"):
         check_waveform(
-            waveform, 
-            dict(),     
-            n_sources=2        # expected 2 sources but will get 5
+            waveform,
+            dict(),
+            n_sources=2,  # expected 2 sources but will get 5
         )
 
 
@@ -154,36 +171,30 @@ def test_check_waveform_using_callables():
         # return constant time series equal to the provided value
         return np.ones((n_series, len(times))) * value
 
-    checked = check_waveform(
-        waveform_fun, 
-        dict(value=1),
-        n_sources=2
-    )
+    checked = check_waveform(waveform_fun, dict(value=1), n_sources=2)
 
-    assert isinstance(checked, partial), \
-        "Expected the waveform function to be converted to a partial object"
-    assert checked.keywords['value'] == 1, \
-        "The provided value of the keyword argument was changed"
+    assert isinstance(
+        checked, partial
+    ), "Expected the waveform function to be converted to a partial object"
+    assert (
+        checked.keywords["value"] == 1
+    ), "The provided value of the keyword argument was changed"
 
 
 def test_check_waveform_callable_bad_shape_raises():
     def waveform_fun(n_series, times, random_state=None):
         # return constant time series, ignore the requested size
         return np.ones((5, 100))
-    
+
     # raises an error since 1000 samples are requested when testing the waveform function
     with pytest.raises(ValueError, match="number of samples"):
-        check_waveform(
-            waveform_fun, 
-            dict(),     
-            n_sources=5        
-        )
+        check_waveform(waveform_fun, dict(), n_sources=5)
 
     with pytest.raises(ValueError, match="number of sources"):
         check_waveform(
-            waveform_fun, 
-            dict(),     
-            n_sources=2       # expected 2 sources, will get 5 
+            waveform_fun,
+            dict(),
+            n_sources=2,  # expected 2 sources, will get 5
         )
 
 
@@ -194,9 +205,9 @@ def test_check_snr_is_none_passes():
 
 @pytest.mark.parametrize("n_sources", [1, 5, 10])
 def test_check_snr_float_passes(n_sources):
-    snr = check_snr(1., n_sources)
+    snr = check_snr(1.0, n_sources)
     assert snr.size == n_sources
-    assert np.all(snr == 1.)
+    assert np.all(snr == 1.0)
 
 
 def test_check_snr_array_valid_shape_passes():
@@ -223,80 +234,76 @@ def test_check_snr_params_snr_is_none():
 
 def test_check_snr_params_no_fmin():
     with pytest.raises(ValueError, match="Please add fmin and fmax"):
-        check_snr_params(dict(fmax=12.), snr=1.)
+        check_snr_params(dict(fmax=12.0), snr=1.0)
 
 
 def test_check_snr_params_no_fmax():
     with pytest.raises(ValueError, match="Please add fmin and fmax"):
-        check_snr_params(dict(fmin=8.), snr=1.)
+        check_snr_params(dict(fmin=8.0), snr=1.0)
 
 
 def test_check_snr_params_negative_fmin_fmax():
     with pytest.raises(ValueError, match="Frequency limits should be positive"):
-        check_snr_params(dict(fmin=-8., fmax=12.), snr=1.)
-        
+        check_snr_params(dict(fmin=-8.0, fmax=12.0), snr=1.0)
+
     with pytest.raises(ValueError, match="Frequency limits should be positive"):
-        check_snr_params(dict(fmin=8., fmax=-12.), snr=1.)
+        check_snr_params(dict(fmin=8.0, fmax=-12.0), snr=1.0)
 
 
 def test_check_names_should_pass():
-    initial = ['m1-lh', 'm1-rh', 's1-lh', 's1-rh']
-    check_names(initial, 4, ['v1-lh', 'v1-rh'])
+    initial = ["m1-lh", "m1-rh", "s1-lh", "s1-rh"]
+    check_names(initial, 4, ["v1-lh", "v1-rh"])
 
 
 def test_check_names_wrong_number():
-    with pytest.raises(ValueError, match='does not match the number of defined'):
-        check_names(['a', 'b', 'c'], 5, [])
+    with pytest.raises(ValueError, match="does not match the number of defined"):
+        check_names(["a", "b", "c"], 5, [])
 
 
 def test_check_names_non_unique():
-    with pytest.raises(ValueError, match='should be unique'):
-        check_names(['a', 'a', 'b'], 3, [])
+    with pytest.raises(ValueError, match="should be unique"):
+        check_names(["a", "a", "b"], 3, [])
 
 
 def test_check_names_wrong_type():
-    with pytest.raises(ValueError, match='to be strings, got int: 1'):
-        check_names(['a', 'b', 1], 3, [])
-    with pytest.raises(ValueError, match='to be strings, got list'):
-        check_names(['a', 'b', ['c', 'd']], 3, [])
+    with pytest.raises(ValueError, match="to be strings, got int: 1"):
+        check_names(["a", "b", 1], 3, [])
+    with pytest.raises(ValueError, match="to be strings, got list"):
+        check_names(["a", "b", ["c", "d"]], 3, [])
 
 
 def test_check_names_empty():
-    with pytest.raises(ValueError, match='should not be empty'):
-        check_names(['a', 'b', ''], 3, [])
+    with pytest.raises(ValueError, match="should not be empty"):
+        check_names(["a", "b", ""], 3, [])
 
 
 def test_check_names_auto():
-    with pytest.raises(ValueError, match='Name auto-s1 should not start with auto'):
-        check_names(['a', 'b', 'auto-s1'], 3, [])
+    with pytest.raises(ValueError, match="Name auto-s1 should not start with auto"):
+        check_names(["a", "b", "auto-s1"], 3, [])
 
 
 def test_check_names_already_exists():
-    with pytest.raises(ValueError, match='Name s1 is already taken'):
-        check_names(['a', 'b', 's1'], 3, ['s1'])
+    with pytest.raises(ValueError, match="Name s1 is already taken"):
+        check_names(["a", "b", "s1"], 3, ["s1"])
 
 
 def test_check_if_source_exists_should_pass():
-    existing = ['aaa', 'bbb']
-    check_if_source_exists('aaa', existing)
+    existing = ["aaa", "bbb"]
+    check_if_source_exists("aaa", existing)
 
 
 def test_check_if_source_exists_should_raise():
-    existing = ['aaa', 'bbb']
-    with pytest.raises(ValueError, match='Source ccc'):
-        check_if_source_exists('ccc', existing)
+    existing = ["aaa", "bbb"]
+    with pytest.raises(ValueError, match="Source ccc"):
+        check_if_source_exists("ccc", existing)
 
 
 def test_check_coupling_params_should_pass():
     def coupling_fn(waveform, sfreq, param1, param2, random_state=0):
         pass
 
-    edge = ('0', '1')
-    coupling_params = dict(
-        method=coupling_fn,
-        param1=0,
-        param2=1
-    )
+    edge = ("0", "1")
+    coupling_params = dict(method=coupling_fn, param1=0, param2=1)
 
     check_coupling_params(coupling_fn, coupling_params, edge)
 
@@ -304,18 +311,15 @@ def test_check_coupling_params_should_pass():
 def test_check_coupling_params_should_raise():
     def coupling_fn(waveform, sfreq, param1, param2, random_state=0):
         if param2 == 1:
-            raise ValueError('Bad value for param2')
+            raise ValueError("Bad value for param2")
 
-    edge = ('0', '1')
-    coupling_params = dict(
-        method=coupling_fn,
-        param1=0
-    )
+    edge = ("0", "1")
+    coupling_params = dict(method=coupling_fn, param1=0)
 
     with pytest.raises(TypeError, match="required positional argument: 'param2'"):
         check_coupling_params(coupling_fn, coupling_params, edge)
 
-    coupling_params['param2'] = 1
+    coupling_params["param2"] = 1
 
     with pytest.raises(ValueError, match="Bad value for param2"):
         check_coupling_params(coupling_fn, coupling_params, edge)
@@ -324,17 +328,17 @@ def test_check_coupling_params_should_raise():
 def test_check_coupling_should_pass():
     from meegsim.coupling import ppc_von_mises
 
-    sources = ['a', 'b', 'c', 'd']
+    sources = ["a", "b", "c", "d"]
     existing = nx.Graph()
-    coupling_params = {'kappa': 1, 'phase_lag': 0}
-    common = {'method': ppc_von_mises, 'fmin': 8, 'fmax': 12}
+    coupling_params = {"kappa": 1, "phase_lag": 0}
+    common = {"method": ppc_von_mises, "fmin": 8, "fmax": 12}
 
-    params = check_coupling(('a', 'b'), coupling_params, common, sources, existing)
+    params = check_coupling(("a", "b"), coupling_params, common, sources, existing)
 
     # Check that common params were added to the dictionary
-    assert 'method' in params
-    assert 'fmin' in params
-    assert 'fmax' in params
+    assert "method" in params
+    assert "fmin" in params
+    assert "fmax" in params
 
 
 def test_check_coupling_bad_edge_format():
@@ -344,46 +348,46 @@ def test_check_coupling_bad_edge_format():
 
     # Too many sources to couple
     with pytest.raises(ValueError, match="should contain two elements"):
-        check_coupling(('a', 'b', 'c', 'd'), {}, {}, [], nx.Graph())
+        check_coupling(("a", "b", "c", "d"), {}, {}, [], nx.Graph())
 
 
 def test_check_coupling_bad_source_name():
-    sources = ['a', 'b', 'c', 'd']
+    sources = ["a", "b", "c", "d"]
 
     # Bad target node
     with pytest.raises(ValueError, match="Source e was not defined yet"):
-        check_coupling(('a', 'e'), {}, {}, sources, nx.Graph())
+        check_coupling(("a", "e"), {}, {}, sources, nx.Graph())
 
     # Bad source node
     with pytest.raises(ValueError, match="Source f was not defined yet"):
-        check_coupling(('f', 'b'), {}, {}, sources, nx.Graph())
+        check_coupling(("f", "b"), {}, {}, sources, nx.Graph())
 
 
 def test_check_coupling_edge_already_exists():
-    sources = ['a', 'b', 'c', 'd']
-    existing = nx.Graph([('a', 'b')])
+    sources = ["a", "b", "c", "d"]
+    existing = nx.Graph([("a", "b")])
 
     with pytest.raises(ValueError, match="multiple definitions are not allowed"):
-        check_coupling(('a', 'b'), {}, {}, sources, existing)
+        check_coupling(("a", "b"), {}, {}, sources, existing)
 
     # Reverse order definition should also be forbidden
     # NOTE: we assume no directionality for now
     with pytest.raises(ValueError, match="multiple definitions are not allowed"):
-        check_coupling(('b', 'a'), {}, {}, sources, existing)
+        check_coupling(("b", "a"), {}, {}, sources, existing)
 
 
 def test_check_coupling_self_loop_edge():
-    sources = ['a']
+    sources = ["a"]
 
     # Bad target node
     with pytest.raises(ValueError, match="is a self-loop"):
-        check_coupling(('a', 'a'), {}, {}, sources, nx.Graph())
+        check_coupling(("a", "a"), {}, {}, sources, nx.Graph())
 
 
 def test_check_coupling_params_not_dict():
     # Too many sources to couple
     with pytest.raises(ValueError, match="as a dictionary, got str"):
-        check_coupling(('a', 'b'), 'params', {}, ['a', 'b'], nx.Graph())
+        check_coupling(("a", "b"), "params", {}, ["a", "b"], nx.Graph())
 
 
 def test_check_coupling_double_definition():
@@ -392,15 +396,15 @@ def test_check_coupling_double_definition():
 
     with warnings.catch_warnings(record=True) as w:
         params = check_coupling(
-            coupling_edge=('a', 'b'), 
-            coupling_params={'param': 1},   # edge-specific value should be saved
-            common_params={'method': coupling_fn, 'param': 0},
-            names=['a', 'b'], 
-            current_graph=nx.Graph()
+            coupling_edge=("a", "b"),
+            coupling_params={"param": 1},  # edge-specific value should be saved
+            common_params={"method": coupling_fn, "param": 0},
+            names=["a", "b"],
+            current_graph=nx.Graph(),
         )
 
         # Check that the edge-specific value was saved
-        assert params['param'] == 1
+        assert params["param"] == 1
 
         # Check that a warning was shown
         assert len(w) == 1
@@ -408,30 +412,30 @@ def test_check_coupling_double_definition():
 
 
 def test_check_coupling_no_method_defined():
-    sources = ['a', 'b', 'c', 'd']
+    sources = ["a", "b", "c", "d"]
     existing = nx.Graph()
-    coupling_params = {'kappa': 1, 'phase_lag': 0}
+    coupling_params = {"kappa": 1, "phase_lag": 0}
 
     with pytest.raises(ValueError, match="method was not defined"):
-        check_coupling(('a', 'b'), coupling_params, {}, sources, existing)
+        check_coupling(("a", "b"), coupling_params, {}, sources, existing)
 
 
 def test_check_coupling_method_not_callable():
-    sources = ['a', 'b', 'c', 'd']
+    sources = ["a", "b", "c", "d"]
     existing = nx.Graph()
-    coupling_params = {'method': 'ppc_von_mises', 'kappa': 1, 'phase_lag': 0}
+    coupling_params = {"method": "ppc_von_mises", "kappa": 1, "phase_lag": 0}
 
     with pytest.raises(ValueError, match="method to be a callable, got str"):
-        check_coupling(('a', 'b'), coupling_params, {}, sources, existing)
+        check_coupling(("a", "b"), coupling_params, {}, sources, existing)
 
 
 def test_check_coupling_bad_params():
     from meegsim.coupling import ppc_von_mises
 
-    sources = ['a', 'b', 'c', 'd']
+    sources = ["a", "b", "c", "d"]
     existing = nx.Graph()
-    coupling_params = {'kappa': 1, 'phase_lag': 0, 'fmin': 8}
-    common = {'method': ppc_von_mises}
+    coupling_params = {"kappa": 1, "phase_lag": 0, "fmin": 8}
+    common = {"method": ppc_von_mises}
 
     with pytest.raises(TypeError, match="argument: 'fmax'"):
-        check_coupling(('a', 'b'), coupling_params, common, sources, existing)
+        check_coupling(("a", "b"), coupling_params, common, sources, existing)

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -5,7 +5,7 @@ from mock import patch
 from meegsim.configuration import SourceConfiguration
 from meegsim.sources import PointSource, PatchSource
 
-from utils.prepare import prepare_source_space
+from utils.prepare import prepare_source_space, prepare_forward
 
 
 def test_sourceconfiguration_to_stc_empty_raises():
@@ -114,3 +114,31 @@ def test_sourceconfiguration_to_raw(apply_forward_mock):
     assert np.all(stc.data == 10), \
         "Custom scaling factor was not applied correctly"
     assert raw == 0, "Output of apply_forward_raw should not be changed"
+
+
+@patch('meegsim.configuration._adjust_sensor_noise', return_value=0)
+def test_sourceconfiguration_to_raw_sensor_space_noise(adjust_noise_mock):
+    src = prepare_source_space(
+        types=['surf', 'surf'],
+        vertices=[[0, 1], [0, 1]]
+    )
+    fwd = prepare_forward(5, 4)
+
+    sc = SourceConfiguration(src, sfreq=250, duration=30)
+    n_samples = sc.sfreq * sc.duration
+    sc._sources = {
+        's1': PointSource('s1', 0, 0, np.ones((n_samples,))),
+        's2': PatchSource('s2', 1, [0, 1], np.ones((n_samples,)))
+    }
+    sc._noise_sources = {
+        'n1': PointSource('n1', 0, 1, np.ones((n_samples,))),
+    }
+
+    # By default, no sensor space noise is added
+    raw = sc.to_raw(fwd, fwd["info"])
+    adjust_noise_mock.assert_not_called()
+
+    # Once called, mock return value should be returned
+    raw = sc.to_raw(fwd, fwd["info"], sensor_noise_level=0.1)
+    adjust_noise_mock.assert_called_once()
+    assert raw == 0

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -78,6 +78,7 @@ def test_builtin_methods():
     # SourceConfiguration methods
     stc = sc.to_stc()
     raw = sc.to_raw(fwd, info)
+    noisy_raw = sc.to_raw(fwd, info, sensor_noise_level=0.25)
 
     # Check that it is possible to simulate data multiple times
     sc_new = sim.simulate(sfreq, duration, fwd, random_state=seed)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -78,7 +78,7 @@ def test_builtin_methods():
     # SourceConfiguration methods
     stc = sc.to_stc()
     raw = sc.to_raw(fwd, info)
-    noisy_raw = sc.to_raw(fwd, info, sensor_noise_level=0.25)
+    sc.to_raw(fwd, info, sensor_noise_level=0.25)
 
     # Check that it is possible to simulate data multiple times
     sc_new = sim.simulate(sfreq, duration, fwd, random_state=seed)

--- a/tests/test_sensor_noise.py
+++ b/tests/test_sensor_noise.py
@@ -1,0 +1,47 @@
+import numpy as np
+import pytest
+
+from meegsim.sensor_noise import _prepare_sensor_noise, _adjustment_factors
+from meegsim.simulate import SourceSimulator
+from meegsim.waveform import narrowband_oscillation
+
+from utils.prepare import prepare_forward, prepare_source_space
+
+
+def test_prepare_sensor_noise():
+    src = prepare_source_space(
+        types=['surf', 'surf'],
+        vertices=[[0, 1], [0, 1]]
+    )
+    fwd = prepare_forward(5, 4)
+
+    sim = SourceSimulator(src)
+    sim.add_noise_sources(location=[(0, 0), (1, 0)])
+    sim.add_point_sources(
+        location=[(0, 1), (1, 1)],
+        waveform=narrowband_oscillation,
+        waveform_params=dict(fmin=8, fmax=12)
+    )
+
+    sc = sim.simulate(sfreq=250, duration=30, random_state=123)
+    raw = sc.to_raw(fwd, fwd["info"])
+    noise = _prepare_sensor_noise(raw, sc.times, sc.random_state)
+
+    # Check that the mean variances of brain activity and noise are equal
+    signal = raw.get_data()
+    signal_var = np.trace(signal @ signal.T)
+    noise_var = np.trace(noise @ noise.T)
+    assert np.allclose(signal_var, noise_var)
+
+
+@pytest.mark.parametrize(
+    "noise_level,expected_f_signal,expected_f_noise", [
+        (0, 1, 0),
+        (0.36, 0.8, 0.6),
+        (1, 0, 1)
+    ]
+)
+def test_adjustment_factors(noise_level, expected_f_signal, expected_f_noise):
+    f_signal, f_noise = _adjustment_factors(noise_level)
+    assert np.allclose(f_signal, expected_f_signal)
+    assert np.allclose(f_noise, expected_f_noise)


### PR DESCRIPTION
New argument of `SourceConfiguration.to_raw()` allows adding the desired level of sensor space noise. The level of X (e.g., 0.1) will mean that 100*X % of the total power will be white noise (see the output of `examples/sensor_space_noise.py` below for different level of sensor-space noise). The total power does not depend on the chosen level of sensor space noise.

**Q:** what do you think about this definition? One could always go with SNR, but somehow I find this more intuitive in this context, not sure why.

![sensor_space_noise](https://github.com/user-attachments/assets/a8566bac-5a15-4a98-ba81-c993908b8cc6)

Closes #55. 