### PR TITLE
ENH: adjustment of global sensor-space SNR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - A desired level of white noise can be added in sensor space to model measurement
 noise ([#58](https://github.com/ctrltz/meegsim/pull/58))
+- Adjustment of global (all signal vs. all noise sources) SNR ([#64](https://github.com/ctrltz/meegsim/pull/64))
 
 ## Version 0.0.1 (2024-10-31)
 

--- a/examples/dummy.py
+++ b/examples/dummy.py
@@ -49,10 +49,8 @@ sim.add_noise_sources(location=select_random, location_params=dict(n=10))
 sim.add_point_sources(
     location=select_random,
     waveform=narrowband_oscillation,
-    snr=1,
     location_params=dict(n=3),
     waveform_params=dict(fmin=8, fmax=12),
-    snr_params=dict(fmin=8, fmax=12),
     names=["s1", "s2", "s3"],
 )
 
@@ -70,8 +68,17 @@ sim.set_coupling(
 print(sim._coupling_graph)
 print(sim._coupling_graph.edges(data=True))
 
-sc = sim.simulate(sfreq, duration, fwd=fwd, random_state=seed)
-raw = sc.to_raw(fwd, info, sensor_noise_level=0.1)
+sc = sim.simulate(
+    sfreq,
+    duration,
+    fwd=fwd,
+    snr_global=10,
+    snr_params=dict(fmin=8, fmax=12),
+    random_state=seed,
+)
+raw = sc.to_raw(fwd, info, sensor_noise_level=0.05)
+
+print([np.var(s.waveform) for s in sc._sources.values()])
 
 spec = raw.compute_psd(n_fft=sfreq, n_overlap=sfreq // 2, n_per_seg=sfreq)
 spec.plot(sphere="eeglab")

--- a/src/meegsim/_check.py
+++ b/src/meegsim/_check.py
@@ -35,6 +35,16 @@ def check_numeric(context, value, bounds=(None, None), allow_none=True):
     return value
 
 
+def check_option(context, value, allowed_values, allow_none=False):
+    if allow_none and value is None:
+        return value
+
+    if value not in allowed_values:
+        raise ValueError(f"The value {value} is not allowed for {context}")
+
+    return value
+
+
 def check_callable(context, fun, *args, **kwargs):
     """
     Check whether the provided function can be run successfully.

--- a/src/meegsim/_check.py
+++ b/src/meegsim/_check.py
@@ -36,6 +36,31 @@ def check_numeric(context, value, bounds=(None, None), allow_none=True):
 
 
 def check_option(context, value, allowed_values, allow_none=False):
+    """
+    Check that the provided value is None (if allowed) or belongs to the list
+    of the allowed values.
+
+    Parameters
+    ----------
+    context : str
+        Context information for the error message.
+    value
+        The value to be checked.
+    allowed_values : list
+        The list of values that are allowed.
+    allow_none : bool
+        If True, None is also allowed.
+
+    Returns
+    -------
+    value
+        The provided value
+
+    Raises
+    ------
+    ValueError
+        If the provided value is not allowed.
+    """
     if allow_none and value is None:
         return value
 

--- a/src/meegsim/simulate.py
+++ b/src/meegsim/simulate.py
@@ -17,8 +17,23 @@ class SourceSimulator:
     ----------
     src : mne.SourceSpaces
         The source space that contains all candidate source locations.
-    snr_mode : str
-        The mode of SNR adjustment.
+    snr_mode : {'global', 'local'}
+        The desired mode for the adjustment of the signal-to-noise ratio (SNR).
+
+        .. note::
+
+          * If ``'global'`` (default), the total power of **all** point/patch sources is
+            adjusted relative to the total power of **all** noise sources. The target
+            value of SNR should be provided in the ``snr_global`` argument of
+            :meth:`~meegsim.simulate.SourceSimulator.simulate`.
+
+          * If ``'local'``, the power of **each** point/patch source is adjusted relative
+            to the total power of **all** noise sources. The target value(s) of SNR
+            should be provided in the ``snr`` argument when adding sources to the
+            simulation via either
+            :meth:`~meegsim.simulate.SourceSimulator.add_point_sources` or
+            :meth:`~meegsim.simulate.SourceSimulator.add_patch_sources`
+
     """
 
     def __init__(self, src, snr_mode="global"):
@@ -69,8 +84,9 @@ class SourceSimulator:
             for every configuration) or as a function that generates the waveforms
             (but differ between configurations if the generation is random).
         snr : None, float, or array, optional
-            SNR values for the defined sources. Can be None (no adjustment of SNR),
-            a single value that is used for all sources or an array with one SNR
+            SNR values for the defined sources, only used if ``snr_mode`` is set to
+            ``'local'``. Can be None (no adjustment of SNR), a single value
+            that is used for all sources or an array with one SNR
             value per source.
         location_params : dict, optional
             Keyword arguments that will be passed to ``location``
@@ -150,8 +166,9 @@ class SourceSimulator:
             (might differ between configurations if the generation is random).
             For each vertex in the patch, the same waveform is currently used.
         snr : None (default), float, or array
-            SNR values for the defined sources. Can be None (no adjustment of SNR,
-            default), a single value that is used for all sources or an array
+            SNR values for the defined sources, only used if ``snr_mode`` is set to
+            ``'local'``. Can be None (no adjustment of SNR, default),
+            a single value that is used for all sources or an array
             with one SNR value per source.
         location_params : dict, optional
             Keyword arguments that will be passed to ``location`` if a
@@ -359,7 +376,7 @@ class SourceSimulator:
             If no adjustment is performed, the forward model is not required.
         snr_global : float or None, optional
             The value of global SNR, only used if the ``snr_mode`` is set to
-            ``"global"``. If None (default), no adjustment of global SNR is performed.
+            ``'global'``. If None (default), no adjustment of global SNR is performed.
         snr_params : dict, optional
             Additional parameters required for the adjustment of global SNR.
             Specify ``fmin`` and ``fmax`` here to define the frequency band which

--- a/src/meegsim/simulate.py
+++ b/src/meegsim/simulate.py
@@ -378,7 +378,7 @@ class SourceSimulator:
         if not (self._source_groups or self._noise_groups):
             raise ValueError("No sources were added to the configuration.")
 
-        # We expect one value that applies to all sources or None
+        # We expect None or one value that applies to all sources
         snr_global = check_snr(snr_global, n_sources=1)
         snr_params = check_snr_params(snr_params, snr_global)
 
@@ -448,7 +448,7 @@ def _simulate(
         )
 
     # Adjust the SNR if needed
-    if snr_mode == "global":
+    if snr_mode == "global" and snr_global is not None:
         tstep = times[1] - times[0]
         sources = _adjust_snr_global(
             src, fwd, snr_global, snr_params, tstep, sources, noise_sources

--- a/src/meegsim/simulate.py
+++ b/src/meegsim/simulate.py
@@ -4,7 +4,7 @@ from ._check import check_coupling
 from .configuration import SourceConfiguration
 from .coupling_graph import _set_coupling
 from .source_groups import PointSourceGroup, PatchSourceGroup
-from .snr import _adjust_snr
+from .snr import _adjust_snr_local
 from .waveform import one_over_f_noise
 
 
@@ -417,6 +417,8 @@ def _simulate(
     # Adjust the SNR if needed
     if is_snr_adjusted:
         tstep = times[1] - times[0]
-        sources = _adjust_snr(src, fwd, tstep, sources, source_groups, noise_sources)
+        sources = _adjust_snr_local(
+            src, fwd, tstep, sources, source_groups, noise_sources
+        )
 
     return sources, noise_sources

--- a/src/meegsim/simulate.py
+++ b/src/meegsim/simulate.py
@@ -340,9 +340,9 @@ class SourceSimulator:
         self,
         sfreq,
         duration,
+        fwd=None,
         snr_global=None,
         snr_params=dict(),
-        fwd=None,
         random_state=None,
     ):
         """
@@ -354,6 +354,9 @@ class SourceSimulator:
             The sampling frequency of the simulated data, in Hz.
         duration : float
             Duration of the simulated data, in seconds.
+        fwd : mne.Forward, optional
+            The forward model, only to be used for the adjustment of SNR.
+            If no adjustment is performed, the forward model is not required.
         snr_global : float or None, optional
             The value of global SNR, only used if the ``snr_mode`` is set to
             ``"global"``. If None (default), no adjustment of global SNR is performed.
@@ -361,9 +364,6 @@ class SourceSimulator:
             Additional parameters required for the adjustment of global SNR.
             Specify ``fmin`` and ``fmax`` here to define the frequency band which
             should used for calculating the SNR.
-        fwd : mne.Forward, optional
-            The forward model, only to be used for the adjustment of SNR.
-            If no adjustment is performed, the forward model is not required.
         random_state : int or None, optional
             The random state can be provided to obtain reproducible configurations.
             If None (default), the simulated data will differ between function calls.

--- a/src/meegsim/simulate.py
+++ b/src/meegsim/simulate.py
@@ -17,7 +17,8 @@ class SourceSimulator:
     ----------
     src : mne.SourceSpaces
         The source space that contains all candidate source locations.
-    snr_mode :
+    snr_mode : str
+        The mode of SNR adjustment.
     """
 
     def __init__(self, src, snr_mode="global"):

--- a/src/meegsim/snr.py
+++ b/src/meegsim/snr.py
@@ -1,5 +1,6 @@
 import numpy as np
 import mne
+import warnings
 
 from scipy.signal import butter, filtfilt
 
@@ -144,19 +145,21 @@ def _adjust_snr_local(src, fwd, tstep, sources, source_groups, noise_sources):
 
 def _adjust_snr_global(src, fwd, snr_global, snr_params, tstep, sources, noise_sources):
     # Combine signal/noise sources
+    if not sources:
+        warnings.warn(
+            "No point/patch sources were added to the simulation, "
+            "skipping the requested adjustment of global SNR."
+        )
+        return sources
+
+    stc_signal = _combine_sources_into_stc(sources.values(), src, tstep)
+
     if not noise_sources:
         raise ValueError(
             "No noise sources were added to the simulation, so the global SNR "
             "cannot be adjusted."
         )
     stc_noise = _combine_sources_into_stc(noise_sources.values(), src, tstep)
-
-    if not sources:
-        raise ValueError(
-            "No point/patch sources were added to the simulation, "
-            "so the global SNR cannot be adjusted."
-        )
-    stc_signal = _combine_sources_into_stc(sources.values(), src, tstep)
 
     # Get sensor-space variance of signal and noise
     fmin, fmax = snr_params["fmin"], snr_params["fmax"]

--- a/src/meegsim/snr.py
+++ b/src/meegsim/snr.py
@@ -106,6 +106,10 @@ def amplitude_adjustment_factor(signal_var, noise_var, target_snr):
 
 
 def _adjust_snr_local(src, fwd, tstep, sources, source_groups, noise_sources):
+    """
+    Perform the adjustment of local SNR: the power of each source is adjusted
+    relative to the power of all noise sources combined.
+    """
     # Get the stc and leadfield of all noise sources
     if not noise_sources:
         raise ValueError(
@@ -144,6 +148,10 @@ def _adjust_snr_local(src, fwd, tstep, sources, source_groups, noise_sources):
 
 
 def _adjust_snr_global(src, fwd, snr_global, snr_params, tstep, sources, noise_sources):
+    """
+    Perform the adjustment of global SNR: the power of all sources combined
+    is adjusted relative to the power of all noise sources combined.
+    """
     # Combine signal/noise sources
     if not sources:
         warnings.warn(

--- a/src/meegsim/snr.py
+++ b/src/meegsim/snr.py
@@ -104,7 +104,7 @@ def amplitude_adjustment_factor(signal_var, noise_var, target_snr):
     return factor
 
 
-def _adjust_snr(src, fwd, tstep, sources, source_groups, noise_sources):
+def _adjust_snr_local(src, fwd, tstep, sources, source_groups, noise_sources):
     # Get the stc and leadfield of all noise sources
     if not noise_sources:
         raise ValueError(

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -17,6 +17,7 @@ from meegsim._check import (
     check_coupling,
     check_coupling_params,
     check_numeric,
+    check_option,
 )
 
 from utils.prepare import prepare_source_space
@@ -43,6 +44,15 @@ def test_check_numeric_out_of_bounds():
 
     with pytest.raises(ValueError, match="Expected var to be 2 or lower"):
         check_numeric("var", 5, bounds=[0, 2])
+
+
+def test_check_option_should_pass():
+    check_option("", "aaa", ["aaa", "bbb"])
+
+
+def test_check_option_bad_option():
+    with pytest.raises(ValueError, match="The value aaa is not allowed for bbb"):
+        check_option("bbb", "aaa", ["ccc", "ddd"])
 
 
 def test_check_callable():

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -28,7 +28,7 @@ def test_builtin_methods():
     duration = 10
     seed = 1234
 
-    sim = SourceSimulator(src)
+    sim = SourceSimulator(src, snr_mode="local")
 
     # 1/f noise (default), fixed location
     sim.add_noise_sources(location=[(0, 0), (0, 2), (0, 4)])
@@ -75,7 +75,7 @@ def test_builtin_methods():
     )
 
     # Actual simulation
-    sc = sim.simulate(sfreq, duration, fwd, random_state=seed)
+    sc = sim.simulate(sfreq, duration, fwd=fwd, random_state=seed)
 
     # SourceConfiguration methods
     stc = sc.to_stc()
@@ -83,10 +83,21 @@ def test_builtin_methods():
     sc.to_raw(fwd, info, sensor_noise_level=0.25)
 
     # Check that it is possible to simulate data multiple times
-    sc_new = sim.simulate(sfreq, duration, fwd, random_state=seed)
+    sc_new = sim.simulate(sfreq, duration, fwd=fwd, random_state=seed)
     stc_new = sc_new.to_stc()
     raw_new = sc_new.to_raw(fwd, info)
 
     # Check that the result is reproducible
     assert np.allclose(stc.data, stc_new.data)
     assert np.allclose(raw.get_data(), raw_new.get_data())
+
+    # Check that the global adjustment of SNR works
+    sim.snr_mode = "global"
+    sc = sim.simulate(
+        sfreq,
+        duration,
+        snr_global=5,
+        snr_params=dict(fmin=8, fmax=12),
+        fwd=fwd,
+        random_state=seed,
+    )

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -335,7 +335,7 @@ def test_simulate():
         assert len(noise_sources) == 4, f"Expected 4 sources, got {len(noise_sources)}"
 
 
-@patch("meegsim.simulate._adjust_snr", return_value=[])
+@patch("meegsim.simulate._adjust_snr_local", return_value=[])
 def test_simulate_snr_adjustment(adjust_snr_mock):
     # return mock PointSource's - 1 noise source, 1 signal source
     simulate_mock = Mock(

--- a/tests/test_snr.py
+++ b/tests/test_snr.py
@@ -7,7 +7,7 @@ import pytest
 from meegsim.snr import (
     get_sensor_space_variance,
     amplitude_adjustment_factor,
-    _adjust_snr,
+    _adjust_snr_local,
 )
 from meegsim.source_groups import PointSourceGroup, PatchSourceGroup
 
@@ -189,7 +189,7 @@ def test_adjust_snr_point(adjust_snr_mock):
     noise_sources = {"n1": prepare_point_source(name="n1")}
     tstep = 0.01
 
-    sources = _adjust_snr(src, fwd, tstep, sources, source_groups, noise_sources)
+    sources = _adjust_snr_local(src, fwd, tstep, sources, source_groups, noise_sources)
 
     # Check the SNR adjustment was performed only once
     adjust_snr_mock.assert_called_once()
@@ -232,7 +232,7 @@ def test_adjust_snr_patch(adjust_snr_mock):
     noise_sources = {"n1": prepare_point_source(name="n1")}
     tstep = 0.01
 
-    sources = _adjust_snr(src, fwd, tstep, sources, source_groups, noise_sources)
+    sources = _adjust_snr_local(src, fwd, tstep, sources, source_groups, noise_sources)
 
     # Check the SNR adjustment was performed only once
     adjust_snr_mock.assert_called_once()
@@ -248,4 +248,4 @@ def test_adjust_snr_no_noise_sources_raises():
 
     # it's only important that the noise sources list is empty
     with pytest.raises(ValueError, match="No noise sources"):
-        _adjust_snr(src, fwd, 0.01, [], [], [])
+        _adjust_snr_local(src, fwd, 0.01, [], [], [])


### PR DESCRIPTION
This PR introduces a global mode for the adjustment of SNR: total power of **all** signal (point/patch) sources is adjusted relative to the total power of **all** noise sources. This should simplify setting the custom distribution of source amplitudes (to come next).