### PR TITLE
ENH: set a custom spatial distribution of source variances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A desired level of white noise can be added in sensor space to model measurement
 noise ([#58](https://github.com/ctrltz/meegsim/pull/58))
 - Adjustment of global (all signal vs. all noise sources) SNR ([#64](https://github.com/ctrltz/meegsim/pull/64))
+- Adjustment of the standard deviation of source activity ([#66](https://github.com/ctrltz/meegsim/pull/66))
+
+### Changed
+
+- Reworked normalization of source activity: by default, all source time courses are scaled to make their standard deviation equal to 1 nAm ([#66](https://github.com/ctrltz/meegsim/pull/66))
 
 ## Version 0.0.1 (2024-10-31)
 

--- a/examples/dummy.py
+++ b/examples/dummy.py
@@ -79,7 +79,6 @@ sc = sim.simulate(
 raw = sc.to_raw(fwd, info, sensor_noise_level=0.05)
 
 print([np.var(s.waveform) for s in sc._sources.values()])
-print([np.mean(s.waveform**2) for s in sc._sources.values()])
 
 spec = raw.compute_psd(n_fft=sfreq, n_overlap=sfreq // 2, n_per_seg=sfreq)
 spec.plot(sphere="eeglab")

--- a/examples/dummy.py
+++ b/examples/dummy.py
@@ -3,6 +3,7 @@ Testing the configuration structure
 """
 
 import json
+import matplotlib.pyplot as plt
 import mne
 import numpy as np
 
@@ -33,7 +34,9 @@ target_snr = 20
 
 # Channel info
 montage = mne.channels.make_standard_montage("standard_1020")
-ch_names = [ch for ch in montage.ch_names if ch not in ["O9", "O10"]]
+ch_names = [
+    ch for ch in montage.ch_names if ch not in ["O9", "O10", "T3", "T4", "T5", "T6"]
+]
 info = mne.create_info(ch_names, sfreq, ch_types="eeg")
 info.set_montage("standard_1020")
 
@@ -43,7 +46,7 @@ fwd = mne.pick_channels_forward(fwd, info.ch_names, ordered=True)
 
 sim = SourceSimulator(src)
 
-sim.add_noise_sources(location=select_random, location_params=dict(n=100))
+sim.add_noise_sources(location=select_random, location_params=dict(n=10))
 
 # Select some vertices randomly
 sim.add_point_sources(
@@ -51,7 +54,7 @@ sim.add_point_sources(
     waveform=narrowband_oscillation,
     location_params=dict(n=3),
     waveform_params=dict(fmin=8, fmax=12),
-    std=[1, 10, 1],
+    std=[1, 1, 10],
     names=["s1", "s2", "s3"],
 )
 
@@ -82,5 +85,6 @@ raw = sc.to_raw(fwd, info, sensor_noise_level=0.05)
 print([np.var(s.waveform) for s in sc._sources.values()])
 
 spec = raw.compute_psd(n_fft=sfreq, n_overlap=sfreq // 2, n_per_seg=sfreq)
+spec.plot_topomap(bands={"alpha": (8, 12)}, sphere="eeglab")
 spec.plot(sphere="eeglab")
-input("Press any key to continue")
+plt.show(block=True)

--- a/examples/dummy.py
+++ b/examples/dummy.py
@@ -72,13 +72,14 @@ sc = sim.simulate(
     sfreq,
     duration,
     fwd=fwd,
-    snr_global=10,
+    snr_global=None,
     snr_params=dict(fmin=8, fmax=12),
     random_state=seed,
 )
 raw = sc.to_raw(fwd, info, sensor_noise_level=0.05)
 
 print([np.var(s.waveform) for s in sc._sources.values()])
+print([np.mean(s.waveform**2) for s in sc._sources.values()])
 
 spec = raw.compute_psd(n_fft=sfreq, n_overlap=sfreq // 2, n_per_seg=sfreq)
 spec.plot(sphere="eeglab")

--- a/examples/dummy.py
+++ b/examples/dummy.py
@@ -43,14 +43,15 @@ fwd = mne.pick_channels_forward(fwd, info.ch_names, ordered=True)
 
 sim = SourceSimulator(src)
 
-sim.add_noise_sources(location=select_random, location_params=dict(n=10))
+sim.add_noise_sources(location=select_random, location_params=dict(n=100))
 
 # Select some vertices randomly
 sim.add_point_sources(
-    location=select_random,
+    location=[(0, 0), (0, 87780), (0, 106307)],
     waveform=narrowband_oscillation,
     location_params=dict(n=3),
     waveform_params=dict(fmin=8, fmax=12),
+    std=[1, 10, 1],
     names=["s1", "s2", "s3"],
 )
 
@@ -72,7 +73,7 @@ sc = sim.simulate(
     sfreq,
     duration,
     fwd=fwd,
-    snr_global=None,
+    snr_global=4,
     snr_params=dict(fmin=8, fmax=12),
     random_state=seed,
 )

--- a/src/meegsim/_check.py
+++ b/src/meegsim/_check.py
@@ -339,8 +339,8 @@ def check_numeric_array(
 ):
     """
     Check the user input in case a list of numeric values for several sources
-    is expected. If allowed, it can be None, a single float value that applies
-    to all sources or an array of values with one for each source.
+    is expected. If allowed, it can be None. Otherwise, a single float value
+    that applies to all sources or an array of values with one for each source.
 
     Parameters
     ----------

--- a/src/meegsim/_check.py
+++ b/src/meegsim/_check.py
@@ -340,12 +340,13 @@ def check_numeric_array(
     """
     Check the user input in case a list of numeric values for several sources
     is expected. If allowed, it can be None. Otherwise, a single float value
-    that applies to all sources or an array of values with one for each source.
+    that applies to all sources or an array of values with one for each source
+    are expected.
 
     Parameters
     ----------
     context : str
-        Context information for the error message
+        Context information for the error message.
     value : None, float, or array
         The provided value(s).
     n_sources : int
@@ -371,7 +372,7 @@ def check_numeric_array(
             f"one {context} value for each of the {n_sources} sources, got {values.size}"
         )
 
-    # Check that are values are numeric and in bounds
+    # Check that values are numeric and, if required, in bounds
     for value in values:
         check_numeric(context, value, bounds=bounds, allow_none=allow_none)
 

--- a/src/meegsim/_check.py
+++ b/src/meegsim/_check.py
@@ -334,25 +334,31 @@ def check_names(names, n_sources, existing):
         raise ValueError("All names should be unique")
 
 
-def check_numeric_list(
+def check_numeric_array(
     context, value, n_sources, bounds=(None, None), allow_none=False
 ):
     """
-    Check the user input for SNR: it can either be None (no adjustment of SNR),
-    a single float value that applies to all sources or an array of values
-    with one for each source.
+    Check the user input in case a list of numeric values for several sources
+    is expected. If allowed, it can be None, a single float value that applies
+    to all sources or an array of values with one for each source.
 
     Parameters
     ----------
-    snr: None, float, or array
-        The provided value(s) for SNR
-    n_sources: int
+    context : str
+        Context information for the error message
+    value : None, float, or array
+        The provided value(s).
+    n_sources : int
         The number of sources.
+    bounds : tuple
+        Bounds for the provided numeric values.
+    allow_none : bool
+        Whether None value is allowed.
 
     Raises
     ------
     ValueError
-        If the provided SNR value(s) do not follow the format described above.
+        If the provided value(s) do not follow the format described above.
     """
 
     if value is None and allow_none:

--- a/src/meegsim/_check.py
+++ b/src/meegsim/_check.py
@@ -334,7 +334,9 @@ def check_names(names, n_sources, existing):
         raise ValueError("All names should be unique")
 
 
-def check_snr(snr, n_sources):
+def check_numeric_list(
+    context, value, n_sources, bounds=(None, None), allow_none=False
+):
     """
     Check the user input for SNR: it can either be None (no adjustment of SNR),
     a single float value that applies to all sources or an array of values
@@ -353,25 +355,25 @@ def check_snr(snr, n_sources):
         If the provided SNR value(s) do not follow the format described above.
     """
 
-    if snr is None:
+    if value is None and allow_none:
         return None
 
-    snr = np.ravel(np.array(snr))
-    if snr.size != 1 and snr.size != n_sources:
+    values = np.ravel(np.array(value))
+    if values.size != 1 and values.size != n_sources:
         raise ValueError(
-            f"Expected either one SNR value that applies to all sources or "
-            f"one SNR value for each of the {n_sources} sources, got {snr.size}"
+            f"Expected either one {context} value that applies to all sources or "
+            f"one {context} value for each of the {n_sources} sources, got {values.size}"
         )
 
-    # Only positive values make sense, raise error if negative ones are provided
-    if np.any(snr < 0):
-        raise ValueError("Each SNR value should be positive")
+    # Check that are values are numeric and in bounds
+    for value in values:
+        check_numeric(context, value, bounds=bounds, allow_none=allow_none)
 
     # Broadcast to all sources if a single value was provided
-    if snr.size == 1:
-        snr = np.tile(snr, (n_sources,))
+    if values.size == 1:
+        values = np.tile(values, (n_sources,))
 
-    return snr
+    return values
 
 
 def check_snr_params(snr_params, snr):

--- a/src/meegsim/configuration.py
+++ b/src/meegsim/configuration.py
@@ -62,7 +62,7 @@ class SourceConfiguration:
 
         return _combine_sources_into_stc(all_sources, self.src, self.tstep)
 
-    def to_raw(self, fwd, info, scaling_factor=1e-6, sensor_noise_level=None):
+    def to_raw(self, fwd, info, sensor_noise_level=None):
         """
         Project the activity of all simulated sources to sensor space.
 
@@ -72,9 +72,6 @@ class SourceConfiguration:
             The forward model.
         info : Info
             The info structure that describes the channel layout.
-        scaling_factor : float, optional
-            The source activity is scaled by this factor before projecting to
-            sensor space. By default, the scaling factor is equal to :math:`10^{-6}`.
         sensor_noise_level : float, optional
             The desired level of sensor-space noise between 0 and 1. For example,
             if 0.1 is specified, 10% of total sensor-space power will stem from
@@ -107,10 +104,8 @@ class SourceConfiguration:
         """
         check_numeric("sensor_noise_level", sensor_noise_level, [0.0, 1.0])
 
-        # Multiply the combined stc by the scaling factor
-        stc_combined = self.to_stc() * scaling_factor
-
-        # Project to sensor space and return
+        # Project source activity to sensor space
+        stc_combined = self.to_stc()
         raw = mne.apply_forward_raw(fwd, stc_combined, info)
 
         # Add sensor space noise if needed

--- a/src/meegsim/coupling.py
+++ b/src/meegsim/coupling.py
@@ -7,6 +7,8 @@ import numpy as np
 from scipy.stats import vonmises
 from scipy.signal import butter, filtfilt, hilbert
 
+from meegsim.utils import normalize_variance
+
 
 def constant_phase_shift(waveform, sfreq, phase_lag, m=1, n=1, random_state=None):
     """
@@ -51,7 +53,7 @@ def constant_phase_shift(waveform, sfreq, phase_lag, m=1, n=1, random_state=None
     waveform_coupled = waveform_amp * np.exp(
         1j * m / n * waveform_angle + 1j * phase_lag
     )
-    return np.real(waveform_coupled)
+    return normalize_variance(np.real(waveform_coupled))
 
 
 def ppc_von_mises(
@@ -122,4 +124,4 @@ def ppc_von_mises(
     tmp_waveform = filtfilt(b, a, tmp_waveform)
     waveform_coupled = waveform_amp * np.exp(1j * np.angle(hilbert(tmp_waveform)))
 
-    return np.real(waveform_coupled)
+    return normalize_variance(np.real(waveform_coupled))

--- a/src/meegsim/coupling_graph.py
+++ b/src/meegsim/coupling_graph.py
@@ -88,11 +88,6 @@ def _set_coupling(sources, coupling_graph, times, random_state):
         The time points for all samples in the waveform.
     random_state : int or None
         The random state that could be fixed to ensure reproducibility.
-
-    Returns
-    -------
-    sources : dict
-        Simulated sources with waveforms adjusted according to the desired coupling.
     """
     walkaround = generate_walkaround(coupling_graph, random_state=random_state)
 
@@ -114,5 +109,3 @@ def _set_coupling(sources, coupling_graph, times, random_state):
             **tmp_coupling_params,
             random_state=random_state,
         )
-
-    return sources

--- a/src/meegsim/coupling_graph.py
+++ b/src/meegsim/coupling_graph.py
@@ -81,7 +81,8 @@ def _set_coupling(sources, coupling_graph, times, random_state):
     Parameters
     ----------
     sources : dict
-        Simulated sources.
+        Simulated sources. Their waveforms are modified in-place by the
+        coupling function(s).
     coupling_graph : nx.Graph
         The coupling graph that describes the desired connectivity pattern.
     times : array-like

--- a/src/meegsim/simulate.py
+++ b/src/meegsim/simulate.py
@@ -1,6 +1,6 @@
 import networkx as nx
 
-from ._check import check_coupling, check_option, check_snr, check_snr_params
+from ._check import check_coupling, check_option, check_numeric_list, check_snr_params
 from .configuration import SourceConfiguration
 from .coupling_graph import _set_coupling
 from .source_groups import PointSourceGroup, PatchSourceGroup
@@ -67,6 +67,7 @@ class SourceSimulator:
         location,
         waveform,
         snr=None,
+        std=1,
         location_params=dict(),
         waveform_params=dict(),
         snr_params=dict(),
@@ -119,6 +120,7 @@ class SourceSimulator:
             location,
             waveform,
             snr=snr,
+            std=std,
             location_params=location_params,
             waveform_params=waveform_params,
             snr_params=snr_params,
@@ -143,6 +145,7 @@ class SourceSimulator:
         location,
         waveform,
         snr=None,
+        std=1,
         location_params=dict(),
         waveform_params=dict(),
         snr_params=dict(),
@@ -207,6 +210,7 @@ class SourceSimulator:
             location,
             waveform,
             snr=snr,
+            std=std,
             location_params=location_params,
             waveform_params=waveform_params,
             extents=extents,
@@ -231,6 +235,7 @@ class SourceSimulator:
         self,
         location,
         waveform=one_over_f_noise,
+        std=1,
         location_params=dict(),
         waveform_params=dict(),
     ):
@@ -274,6 +279,7 @@ class SourceSimulator:
             location,
             waveform,
             snr=None,
+            std=std,
             location_params=location_params,
             waveform_params=waveform_params,
             snr_params=dict(),
@@ -400,7 +406,9 @@ class SourceSimulator:
             raise ValueError("No sources were added to the configuration.")
 
         # We expect None or one value that applies to all sources
-        snr_global = check_snr(snr_global, n_sources=1)
+        snr_global = check_numeric_list(
+            "global SNR", snr_global, n_sources=1, bounds=(0, None), allow_none=True
+        )
         snr_params = check_snr_params(snr_params, snr_global)
 
         is_global_snr_adjusted = self.snr_mode == "global" and snr_global is not None

--- a/src/meegsim/simulate.py
+++ b/src/meegsim/simulate.py
@@ -467,26 +467,24 @@ def _simulate(
     # Setup the desired coupling patterns
     # The time courses are changed for some of the sources in the process
     if coupling_graph.number_of_edges() > 0:
-        sources = _set_coupling(
-            sources, coupling_graph, times, random_state=random_state
-        )
-
-    # Adjust the SNR if needed
-    if snr_mode == "global" and snr_global is not None:
-        tstep = times[1] - times[0]
-        sources = _adjust_snr_global(
-            src, fwd, snr_global, snr_params, tstep, sources, noise_sources
-        )
-    elif is_local_snr_adjusted:
-        tstep = times[1] - times[0]
-        sources = _adjust_snr_local(
-            src, fwd, tstep, sources, source_groups, noise_sources
-        )
+        _set_coupling(sources, coupling_graph, times, random_state=random_state)
 
     # Set the base amplitude
+    # NOTE: this should also be helpful to get less warnings about unreasonably
+    # high values from apply_forward_raw
     for s in sources.values():
         s.waveform *= base_amplitude
     for ns in noise_sources.values():
         ns.waveform *= base_amplitude
+
+    # Adjust the SNR if needed
+    if snr_mode == "global" and snr_global is not None:
+        tstep = times[1] - times[0]
+        _adjust_snr_global(
+            src, fwd, snr_global, snr_params, tstep, sources, noise_sources
+        )
+    elif is_local_snr_adjusted:
+        tstep = times[1] - times[0]
+        _adjust_snr_local(src, fwd, tstep, sources, source_groups, noise_sources)
 
     return sources, noise_sources

--- a/src/meegsim/simulate.py
+++ b/src/meegsim/simulate.py
@@ -37,7 +37,6 @@ class SourceSimulator:
         The source activity is scaled by the base amplitude before projecting to
         sensor space. By default, the base amplitude is equal to :math:`10^{-9}`,
         corresponding to 1 nAm.
-
     """
 
     def __init__(self, src, snr_mode="global", base_amplitude=1e-9):
@@ -469,13 +468,13 @@ def _simulate(
     if coupling_graph.number_of_edges() > 0:
         _set_coupling(sources, coupling_graph, times, random_state=random_state)
 
-    # Set the base amplitude
+    # Set the standard deviation of all sources w.r.t. base amplitude
     # NOTE: this should also be helpful to get less warnings about unreasonably
     # high values from apply_forward_raw
     for s in sources.values():
-        s.waveform *= base_amplitude
+        s.waveform *= base_amplitude * s.std
     for ns in noise_sources.values():
-        ns.waveform *= base_amplitude
+        ns.waveform *= base_amplitude * s.std
 
     # Adjust the SNR if needed
     if snr_mode == "global" and snr_global is not None:

--- a/src/meegsim/simulate.py
+++ b/src/meegsim/simulate.py
@@ -67,7 +67,7 @@ class SourceSimulator:
         location,
         waveform,
         snr=None,
-        std=1,
+        std=1.0,
         location_params=dict(),
         waveform_params=dict(),
         snr_params=dict(),
@@ -93,6 +93,14 @@ class SourceSimulator:
             ``'local'``. Can be None (no adjustment of SNR), a single value
             that is used for all sources or an array with one SNR
             value per source.
+        std : float or array, optional
+            Desired standard deviation of the source activity, provided either as a
+            single value that applied to all sources or an array with one value per
+            source. This parameter can be used in combination with the global SNR
+            mode to set an arbitrary spatial distribution of source activity.
+            By default, 1 is used so the variance of all sources is the same.
+            If the value local SNR is specified, this parameter will effectively
+            be ignored.
         location_params : dict, optional
             Keyword arguments that will be passed to ``location``
             if a function is provided.
@@ -145,7 +153,7 @@ class SourceSimulator:
         location,
         waveform,
         snr=None,
-        std=1,
+        std=1.0,
         location_params=dict(),
         waveform_params=dict(),
         snr_params=dict(),
@@ -177,6 +185,14 @@ class SourceSimulator:
             ``'local'``. Can be None (no adjustment of SNR, default),
             a single value that is used for all sources or an array
             with one SNR value per source.
+        std : float or array, optional
+            Desired standard deviation of the source activity, provided either as a
+            single value that applied to all sources or an array with one value per
+            source. This parameter can be used in combination with the global SNR
+            mode to set an arbitrary spatial distribution of source activity.
+            By default, 1 is used so the variance of all sources is the same.
+            If the value local SNR is specified, this parameter will effectively
+            be ignored.
         location_params : dict, optional
             Keyword arguments that will be passed to ``location`` if a
             function is provided.
@@ -235,7 +251,7 @@ class SourceSimulator:
         self,
         location,
         waveform=one_over_f_noise,
-        std=1,
+        std=1.0,
         location_params=dict(),
         waveform_params=dict(),
     ):
@@ -254,6 +270,11 @@ class SourceSimulator:
         waveform : array or callable
             Waveform provided either directly as an array or as a function.
             By default, 1/f noise with the slope of 1 is used for all noise sources.
+        std : float or array, optional
+            Desired standard deviation of the source activity, provided either as a
+            single value that applied to all sources or an array with one value per
+            source. By default, 1 is used so the variance of all noise sources is
+            the same.
         location_params : dict, optional
             Keyword arguments that will be passed to ``location`` if a
             function is provided.

--- a/src/meegsim/simulate.py
+++ b/src/meegsim/simulate.py
@@ -1,6 +1,6 @@
 import networkx as nx
 
-from ._check import check_coupling, check_option, check_numeric_list, check_snr_params
+from ._check import check_coupling, check_option, check_numeric_array, check_snr_params
 from .configuration import SourceConfiguration
 from .coupling_graph import _set_coupling
 from .source_groups import PointSourceGroup, PatchSourceGroup
@@ -406,7 +406,7 @@ class SourceSimulator:
             raise ValueError("No sources were added to the configuration.")
 
         # We expect None or one value that applies to all sources
-        snr_global = check_numeric_list(
+        snr_global = check_numeric_array(
             "global SNR", snr_global, n_sources=1, bounds=(0, None), allow_none=True
         )
         snr_params = check_snr_params(snr_params, snr_global)

--- a/src/meegsim/simulate.py
+++ b/src/meegsim/simulate.py
@@ -25,7 +25,9 @@ class SourceSimulator:
           * If ``'global'`` (default), the total power of **all** point/patch sources is
             adjusted relative to the total power of **all** noise sources. The target
             value of SNR should be provided in the ``snr_global`` argument of
-            :meth:`~meegsim.simulate.SourceSimulator.simulate`.
+            :meth:`~meegsim.simulate.SourceSimulator.simulate`. The spatial distribution
+            of source activity can be controlled using the ``std`` argument when adding
+            sources.
 
           * If ``'local'``, the power of **each** point/patch source is adjusted relative
             to the total power of **all** noise sources. The target value(s) of SNR

--- a/src/meegsim/simulate.py
+++ b/src/meegsim/simulate.py
@@ -97,7 +97,7 @@ class SourceSimulator:
             value per source.
         std : float or array, optional
             Desired standard deviation of the source activity, provided either as a
-            single value that applies to all sources or an array with one value per
+            single value that applies to all sources or as an array with one value per
             source. This parameter can be used in combination with the global SNR
             mode to set an arbitrary spatial distribution of source activity.
             By default, 1 is used so the variance of all sources is the same.
@@ -189,7 +189,7 @@ class SourceSimulator:
             with one SNR value per source.
         std : float or array, optional
             Desired standard deviation of the source activity, provided either as a
-            single value that applies to all sources or an array with one value per
+            single value that applies to all sources or as an array with one value per
             source. This parameter can be used in combination with the global SNR
             mode to set an arbitrary spatial distribution of source activity.
             By default, 1 is used so the variance of all sources is the same.
@@ -274,7 +274,7 @@ class SourceSimulator:
             By default, 1/f noise with the slope of 1 is used for all noise sources.
         std : float or array, optional
             Desired standard deviation of the source activity, provided either as a
-            single value that applies to all sources or an array with one value per
+            single value that applies to all sources or as an array with one value per
             source. By default, 1 is used so the variance of all noise sources is
             the same.
         location_params : dict, optional

--- a/src/meegsim/simulate.py
+++ b/src/meegsim/simulate.py
@@ -33,15 +33,15 @@ class SourceSimulator:
             simulation via either
             :meth:`~meegsim.simulate.SourceSimulator.add_point_sources` or
             :meth:`~meegsim.simulate.SourceSimulator.add_patch_sources`
-    base_amplitude : float, optional
-        The source activity is scaled by the base amplitude before projecting to
-        sensor space. By default, the base amplitude is equal to :math:`10^{-9}`,
-        corresponding to 1 nAm.
+    base_std : float, optional
+        The source activity is scaled by the base standard deviation before
+        projecting to sensor space. By default, it is equal to :math:`10^{-9}`,
+        corresponding to the dipolar moment of 1 nAm.
     """
 
-    def __init__(self, src, snr_mode="global", base_amplitude=1e-9):
+    def __init__(self, src, snr_mode="global", base_std=1e-9):
         self.src = src
-        self.base_amplitude = base_amplitude
+        self.base_std = base_std
 
         # Store groups of sources that were defined with one command
         # Store 'signal' and 'noise' separately to ease the calculation of SNR
@@ -431,7 +431,7 @@ class SourceSimulator:
             src=self.src,
             times=sc.times,
             fwd=fwd,
-            base_amplitude=self.base_amplitude,
+            base_std=self.base_std,
             random_state=random_state,
         )
 
@@ -453,7 +453,7 @@ def _simulate(
     src,
     times,
     fwd,
-    base_amplitude,
+    base_std,
     random_state=None,
 ):
     """
@@ -476,13 +476,13 @@ def _simulate(
     if coupling_graph.number_of_edges() > 0:
         _set_coupling(sources, coupling_graph, times, random_state=random_state)
 
-    # Set the standard deviation of all sources w.r.t. base amplitude
+    # Set the standard deviation of all sources w.r.t. base std
     # NOTE: this should also be helpful to get less warnings about unreasonably
     # high values from apply_forward_raw
     for s in sources.values():
-        s.waveform *= base_amplitude * s.std
-    for ns in noise_sources.values():
-        ns.waveform *= base_amplitude * s.std
+        s.waveform *= base_std * s.std
+    for s in noise_sources.values():
+        s.waveform *= base_std * s.std
 
     # Adjust the SNR if needed
     if snr_mode == "global" and snr_global is not None:

--- a/src/meegsim/simulate.py
+++ b/src/meegsim/simulate.py
@@ -97,11 +97,11 @@ class SourceSimulator:
             value per source.
         std : float or array, optional
             Desired standard deviation of the source activity, provided either as a
-            single value that applied to all sources or an array with one value per
+            single value that applies to all sources or an array with one value per
             source. This parameter can be used in combination with the global SNR
             mode to set an arbitrary spatial distribution of source activity.
             By default, 1 is used so the variance of all sources is the same.
-            If the value local SNR is specified, this parameter will effectively
+            If the value of local SNR is specified, this parameter will effectively
             be ignored.
         location_params : dict, optional
             Keyword arguments that will be passed to ``location``
@@ -189,11 +189,11 @@ class SourceSimulator:
             with one SNR value per source.
         std : float or array, optional
             Desired standard deviation of the source activity, provided either as a
-            single value that applied to all sources or an array with one value per
+            single value that applies to all sources or an array with one value per
             source. This parameter can be used in combination with the global SNR
             mode to set an arbitrary spatial distribution of source activity.
             By default, 1 is used so the variance of all sources is the same.
-            If the value local SNR is specified, this parameter will effectively
+            If the value of local SNR is specified, this parameter will effectively
             be ignored.
         location_params : dict, optional
             Keyword arguments that will be passed to ``location`` if a
@@ -274,7 +274,7 @@ class SourceSimulator:
             By default, 1/f noise with the slope of 1 is used for all noise sources.
         std : float or array, optional
             Desired standard deviation of the source activity, provided either as a
-            single value that applied to all sources or an array with one value per
+            single value that applies to all sources or an array with one value per
             source. By default, 1 is used so the variance of all noise sources is
             the same.
         location_params : dict, optional
@@ -501,7 +501,7 @@ def _simulate(
 
     # Set the standard deviation of all sources w.r.t. base std
     # NOTE: this should also be helpful to get less warnings about unreasonably
-    # high values from apply_forward_raw
+    # high values of source activity from apply_forward_raw
     for s in sources.values():
         s.waveform *= base_std * s.std
     for s in noise_sources.values():

--- a/src/meegsim/snr.py
+++ b/src/meegsim/snr.py
@@ -144,8 +144,6 @@ def _adjust_snr_local(src, fwd, tstep, sources, source_groups, noise_sources):
             factor = amplitude_adjustment_factor(signal_var, noise_var, target_snr)
             s.waveform *= factor
 
-    return sources
-
 
 def _adjust_snr_global(src, fwd, snr_global, snr_params, tstep, sources, noise_sources):
     """
@@ -158,7 +156,7 @@ def _adjust_snr_global(src, fwd, snr_global, snr_params, tstep, sources, noise_s
             "No point/patch sources were added to the simulation, "
             "skipping the requested adjustment of global SNR."
         )
-        return sources
+        return
 
     stc_signal = _combine_sources_into_stc(sources.values(), src, tstep)
 
@@ -182,5 +180,3 @@ def _adjust_snr_global(src, fwd, snr_global, snr_params, tstep, sources, noise_s
     factor = amplitude_adjustment_factor(signal_var, noise_var, snr_global)
     for s in sources.values():
         s.waveform *= factor
-
-    return sources

--- a/src/meegsim/snr.py
+++ b/src/meegsim/snr.py
@@ -108,7 +108,8 @@ def amplitude_adjustment_factor(signal_var, noise_var, target_snr):
 def _adjust_snr_local(src, fwd, tstep, sources, source_groups, noise_sources):
     """
     Perform the adjustment of local SNR: the power of each source is adjusted
-    relative to the power of all noise sources combined.
+    relative to the power of all noise sources combined. The waveforms are
+    adjusted in-place.
     """
     # Get the stc and leadfield of all noise sources
     if not noise_sources:
@@ -148,7 +149,8 @@ def _adjust_snr_local(src, fwd, tstep, sources, source_groups, noise_sources):
 def _adjust_snr_global(src, fwd, snr_global, snr_params, tstep, sources, noise_sources):
     """
     Perform the adjustment of global SNR: the power of all sources combined
-    is adjusted relative to the power of all noise sources combined.
+    is adjusted relative to the power of all noise sources combined. The
+    waveforms are adjusted in-place.
     """
     # Combine signal/noise sources
     if not sources:

--- a/src/meegsim/source_groups.py
+++ b/src/meegsim/source_groups.py
@@ -6,7 +6,7 @@ defined by the user until we actually start simulating the data.
 from ._check import (
     check_location,
     check_waveform,
-    check_snr,
+    check_numeric_list,
     check_snr_params,
     check_names,
     check_extents,
@@ -43,7 +43,7 @@ class _BaseSourceGroup:
 
 
 class PointSourceGroup(_BaseSourceGroup):
-    def __init__(self, n_sources, location, waveform, snr, snr_params, names):
+    def __init__(self, n_sources, location, waveform, snr, snr_params, std, names):
         super().__init__()
 
         # Store the defined number of vertices to raise an error
@@ -55,6 +55,7 @@ class PointSourceGroup(_BaseSourceGroup):
         self.waveform = waveform
         self.snr = snr
         self.snr_params = snr_params
+        self.std = std
         self.names = names
 
     def __repr__(self):
@@ -79,6 +80,7 @@ class PointSourceGroup(_BaseSourceGroup):
             self.n_sources,
             self.location,
             self.waveform,
+            self.std,
             self.names,
             random_state=random_state,
         )
@@ -90,6 +92,7 @@ class PointSourceGroup(_BaseSourceGroup):
         location,
         waveform,
         snr,
+        std,
         location_params,
         waveform_params,
         snr_params,
@@ -134,8 +137,11 @@ class PointSourceGroup(_BaseSourceGroup):
         # Check the user input
         location, n_sources = check_location(location, location_params, src)
         waveform = check_waveform(waveform, waveform_params, n_sources)
-        snr = check_snr(snr, n_sources)
+        snr = check_numeric_list(
+            "SNR", snr, n_sources, bounds=(0, None), allow_none=True
+        )
         snr_params = check_snr_params(snr_params, snr)
+        std = check_numeric_list("std", std, n_sources, bounds=(0, None))
 
         # Auto-generate or check the provided source names
         if not names:
@@ -143,11 +149,13 @@ class PointSourceGroup(_BaseSourceGroup):
         else:
             check_names(names, n_sources, existing)
 
-        return cls(n_sources, location, waveform, snr, snr_params, names)
+        return cls(n_sources, location, waveform, snr, snr_params, std, names)
 
 
 class PatchSourceGroup(_BaseSourceGroup):
-    def __init__(self, n_sources, location, waveform, snr, snr_params, extents, names):
+    def __init__(
+        self, n_sources, location, waveform, snr, snr_params, std, extents, names
+    ):
         super().__init__()
 
         # Store the defined number of vertices to raise an error
@@ -159,6 +167,7 @@ class PatchSourceGroup(_BaseSourceGroup):
         self.waveform = waveform
         self.snr = snr
         self.snr_params = snr_params
+        self.std = std
         self.names = names
         self.extents = extents
 
@@ -184,6 +193,7 @@ class PatchSourceGroup(_BaseSourceGroup):
             self.n_sources,
             self.location,
             self.waveform,
+            self.std,
             self.names,
             self.extents,
             random_state=random_state,
@@ -199,6 +209,7 @@ class PatchSourceGroup(_BaseSourceGroup):
         location_params,
         waveform_params,
         snr_params,
+        std,
         extents,
         names,
         group,
@@ -243,8 +254,11 @@ class PatchSourceGroup(_BaseSourceGroup):
         # Check the user input
         location, n_sources = check_location(location, location_params, src)
         waveform = check_waveform(waveform, waveform_params, n_sources)
-        snr = check_snr(snr, n_sources)
+        snr = check_numeric_list(
+            "SNR", snr, n_sources, bounds=(0, None), allow_none=True
+        )
         snr_params = check_snr_params(snr_params, snr)
+        std = check_numeric_list("std", std, n_sources, bounds=(0, None))
         extents = check_extents(extents, n_sources)
 
         # Auto-generate or check the provided source names
@@ -253,4 +267,4 @@ class PatchSourceGroup(_BaseSourceGroup):
         else:
             check_names(names, n_sources, existing)
 
-        return cls(n_sources, location, waveform, snr, snr_params, extents, names)
+        return cls(n_sources, location, waveform, snr, snr_params, std, extents, names)

--- a/src/meegsim/source_groups.py
+++ b/src/meegsim/source_groups.py
@@ -114,6 +114,8 @@ class PointSourceGroup(_BaseSourceGroup):
             The waveform provided by the user.
         snr: None, float, or array
             The SNR values provided by the user.
+        std: float or array
+            The values of standard deviation provided by the user.
         location_params: dict, optional
             Additional keyword arguments for the location function.
         waveform_params: dict, optional
@@ -206,10 +208,10 @@ class PatchSourceGroup(_BaseSourceGroup):
         location,
         waveform,
         snr,
+        std,
         location_params,
         waveform_params,
         snr_params,
-        std,
         extents,
         names,
         group,
@@ -228,13 +230,15 @@ class PatchSourceGroup(_BaseSourceGroup):
         waveform: list of callable
             The waveform provided by the user.
         snr:
-            TODO: fix when finalizing SNR
+            The SNR values provided by the user.
+        std: float or array
+            The values of standard deviation provided by the user.
         location_params: dict, optional
             Additional keyword arguments for the location function.
         waveform_params: dict, optional
             Additional keyword arguments for the waveform function.
         snr_params:
-            TODO: fix when finalizing SNR
+            Additional parameters for the adjustment of SNR.
         extents: list
             Extents (radius in mm) of each patch provided by the user.
         names:

--- a/src/meegsim/source_groups.py
+++ b/src/meegsim/source_groups.py
@@ -6,7 +6,7 @@ defined by the user until we actually start simulating the data.
 from ._check import (
     check_location,
     check_waveform,
-    check_numeric_list,
+    check_numeric_array,
     check_snr_params,
     check_names,
     check_extents,
@@ -137,11 +137,11 @@ class PointSourceGroup(_BaseSourceGroup):
         # Check the user input
         location, n_sources = check_location(location, location_params, src)
         waveform = check_waveform(waveform, waveform_params, n_sources)
-        snr = check_numeric_list(
+        snr = check_numeric_array(
             "SNR", snr, n_sources, bounds=(0, None), allow_none=True
         )
         snr_params = check_snr_params(snr_params, snr)
-        std = check_numeric_list("std", std, n_sources, bounds=(0, None))
+        std = check_numeric_array("std", std, n_sources, bounds=(0, None))
 
         # Auto-generate or check the provided source names
         if not names:
@@ -254,11 +254,11 @@ class PatchSourceGroup(_BaseSourceGroup):
         # Check the user input
         location, n_sources = check_location(location, location_params, src)
         waveform = check_waveform(waveform, waveform_params, n_sources)
-        snr = check_numeric_list(
+        snr = check_numeric_array(
             "SNR", snr, n_sources, bounds=(0, None), allow_none=True
         )
         snr_params = check_snr_params(snr_params, snr)
-        std = check_numeric_list("std", std, n_sources, bounds=(0, None))
+        std = check_numeric_array("std", std, n_sources, bounds=(0, None))
         extents = check_extents(extents, n_sources)
 
         # Auto-generate or check the provided source names

--- a/src/meegsim/sources.py
+++ b/src/meegsim/sources.py
@@ -151,7 +151,7 @@ class PointSource(_BaseSource):
 
     @classmethod
     def create(
-        cls, src, times, n_sources, location, waveform, names, random_state=None
+        cls, src, times, n_sources, location, waveform, stds, names, random_state=None
     ):
         """
         This function creates point sources according to the provided input.
@@ -177,7 +177,7 @@ class PointSource(_BaseSource):
 
         # Create point sources and save them as a group
         sources = []
-        for (src_idx, vertno), waveform, name in zip(vertices, data, names):
+        for (src_idx, vertno), waveform, std, name in zip(vertices, data, stds, names):
             hemi = _extract_hemi(src[src_idx])
             sources.append(
                 cls(
@@ -185,6 +185,7 @@ class PointSource(_BaseSource):
                     src_idx=src_idx,
                     vertno=vertno,
                     waveform=waveform,
+                    std=std,
                     hemi=hemi,
                 )
             )
@@ -242,6 +243,7 @@ class PatchSource(_BaseSource):
         n_sources,
         location,
         waveform,
+        stds,
         names,
         extents,
         random_state=None,
@@ -294,8 +296,8 @@ class PatchSource(_BaseSource):
 
         # Create patch sources and save them as a group
         sources = []
-        for (src_idx, _), patch_vertno, waveform, name in zip(
-            vertices, patch_vertices, data, names
+        for (src_idx, _), patch_vertno, waveform, std, name in zip(
+            vertices, patch_vertices, data, stds, names
         ):
             hemi = _extract_hemi(src[src_idx])
             sources.append(
@@ -304,6 +306,7 @@ class PatchSource(_BaseSource):
                     src_idx=src_idx,
                     vertno=patch_vertno,
                     waveform=waveform,
+                    std=std,
                     hemi=hemi,
                 )
             )

--- a/src/meegsim/sources.py
+++ b/src/meegsim/sources.py
@@ -18,7 +18,7 @@ class _BaseSource:
 
     kind = "base"
 
-    def __init__(self, waveform, std=1):
+    def __init__(self, waveform, std=1.0):
         # Current constraint: one source corresponds to one waveform
         # Point source: the waveform is present in one vertex
         # Patch source: the waveform is mixed with noise in several vertices
@@ -128,7 +128,7 @@ class PointSource(_BaseSource):
 
     kind = "point"
 
-    def __init__(self, name, src_idx, vertno, waveform, std=1, hemi=None):
+    def __init__(self, name, src_idx, vertno, waveform, std=1.0, hemi=None):
         super().__init__(waveform, std)
 
         self.name = name
@@ -212,7 +212,7 @@ class PatchSource(_BaseSource):
 
     kind = "patch"
 
-    def __init__(self, name, src_idx, vertno, waveform, std=1, hemi=None):
+    def __init__(self, name, src_idx, vertno, waveform, std=1.0, hemi=None):
         super().__init__(waveform, std)
 
         self.name = name

--- a/src/meegsim/sources.py
+++ b/src/meegsim/sources.py
@@ -18,11 +18,12 @@ class _BaseSource:
 
     kind = "base"
 
-    def __init__(self, waveform):
+    def __init__(self, waveform, std=1):
         # Current constraint: one source corresponds to one waveform
         # Point source: the waveform is present in one vertex
         # Patch source: the waveform is mixed with noise in several vertices
         self.waveform = waveform
+        self.std = std
 
     @property
     def data(self):
@@ -127,8 +128,8 @@ class PointSource(_BaseSource):
 
     kind = "point"
 
-    def __init__(self, name, src_idx, vertno, waveform, hemi=None):
-        super().__init__(waveform)
+    def __init__(self, name, src_idx, vertno, waveform, std=1, hemi=None):
+        super().__init__(waveform, std)
 
         self.name = name
         self.src_idx = src_idx
@@ -210,8 +211,8 @@ class PatchSource(_BaseSource):
 
     kind = "patch"
 
-    def __init__(self, name, src_idx, vertno, waveform, hemi=None):
-        super().__init__(waveform)
+    def __init__(self, name, src_idx, vertno, waveform, std=1, hemi=None):
+        super().__init__(waveform, std)
 
         self.name = name
         self.src_idx = src_idx

--- a/src/meegsim/utils.py
+++ b/src/meegsim/utils.py
@@ -67,9 +67,9 @@ def combine_stcs(stc1, stc2):
     return stc
 
 
-def normalize_power(data):
+def normalize_variance(data):
     """
-    Divide the time series by its norm to normalize the variance.
+    Divide the time series by its standard deviation to normalize the variance.
 
     Parameters
     ----------
@@ -79,10 +79,13 @@ def normalize_power(data):
     Returns
     -------
     data: array
-        Normalized time series. The norm of each row is equal to 1.
+        Normalized time series. The variance of each row is equal to 1.
     """
 
-    data /= np.linalg.norm(data, axis=1)[:, np.newaxis]
+    if data.ndim == 1:
+        return data / np.std(data)
+
+    data /= np.std(data, axis=-1)[:, np.newaxis]
     return data
 
 

--- a/src/meegsim/utils.py
+++ b/src/meegsim/utils.py
@@ -69,7 +69,8 @@ def combine_stcs(stc1, stc2):
 
 def normalize_variance(data):
     """
-    Divide the time series by its standard deviation to normalize the variance.
+    Divide the time series by their standard deviation to make their
+    variance equal to 1.
 
     Parameters
     ----------

--- a/src/meegsim/waveform.py
+++ b/src/meegsim/waveform.py
@@ -8,7 +8,7 @@ import warnings
 
 from scipy.signal import butter, filtfilt
 
-from .utils import normalize_power, get_sfreq
+from .utils import normalize_variance, get_sfreq
 
 
 def narrowband_oscillation(
@@ -67,7 +67,7 @@ def narrowband_oscillation(
     data = rng.standard_normal(size=(n_series, times.size))
     b, a = butter(N=order, Wn=np.array([fmin, fmax]) / fs * 2, btype="bandpass")
     data = filtfilt(b, a, data, axis=1)
-    return normalize_power(data)
+    return normalize_variance(data)
 
 
 def one_over_f_noise(n_series, times, *, slope=1, random_state=None):
@@ -98,7 +98,7 @@ def one_over_f_noise(n_series, times, *, slope=1, random_state=None):
     data = cn.powerlaw_psd_gaussian(
         slope, size=(n_series, times.size), random_state=random_state
     )
-    return normalize_power(data)
+    return normalize_variance(data)
 
 
 def white_noise(n_series, times, *, random_state=None):
@@ -126,4 +126,4 @@ def white_noise(n_series, times, *, random_state=None):
 
     rng = np.random.default_rng(seed=random_state)
     data = rng.standard_normal(size=(n_series, times.size))
-    return normalize_power(data)
+    return normalize_variance(data)

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -11,7 +11,7 @@ from meegsim._check import (
     check_location,
     check_waveform,
     check_names,
-    check_numeric_list,
+    check_numeric_array,
     check_snr_params,
     check_if_source_exists,
     check_coupling,
@@ -208,33 +208,38 @@ def test_check_waveform_callable_bad_shape_raises():
         )
 
 
-def test_check_snr_is_none_passes():
-    snr = check_numeric_list(None, 5)
+def test_check_numeric_array_none_passes_if_allowed():
+    snr = check_numeric_array("value", None, 5, allow_none=True)
     assert snr is None
 
 
+def test_check_numeric_array_none_raises_if_not_allowed():
+    with pytest.raises(ValueError, match="Expected value to be a float number"):
+        check_numeric_array("value", None, 5, allow_none=False)
+
+
 @pytest.mark.parametrize("n_sources", [1, 5, 10])
-def test_check_snr_float_passes(n_sources):
-    snr = check_numeric_list(1.0, n_sources)
+def test_check_numeric_array_float_passes(n_sources):
+    snr = check_numeric_array("float", 1.0, n_sources)
     assert snr.size == n_sources
     assert np.all(snr == 1.0)
 
 
-def test_check_snr_array_valid_shape_passes():
+def test_check_numeric_array_out_of_bounds_raises():
+    with pytest.raises(ValueError, match="Expected float to be 0 or greater"):
+        check_numeric_array("float", -1.0, 1, bounds=(0, None))
+
+
+def test_check_numeric_array_valid_shape_passes():
     initial = [1, 2, 3, 4, 5]
-    snr = check_numeric_list(initial, 5)
+    snr = check_numeric_array("array", initial, 5)
     assert np.array_equal(snr, initial)
 
 
-def test_check_snr_array_invalid_shape_raises():
+def test_check_numeric_array_invalid_shape_raises():
     initial = [1, 2, 3, 4, 5]
     with pytest.raises(ValueError, match="of the 3 sources, got 5"):
-        check_numeric_list(initial, 3)
-
-
-def test_check_snr_negative_snr_raises():
-    with pytest.raises(ValueError, match="Each SNR value should be positive"):
-        check_numeric_list([-1, 0, 1], 3)
+        check_numeric_array("array", initial, 3)
 
 
 def test_check_snr_params_snr_is_none():

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -11,7 +11,7 @@ from meegsim._check import (
     check_location,
     check_waveform,
     check_names,
-    check_snr,
+    check_numeric_list,
     check_snr_params,
     check_if_source_exists,
     check_coupling,
@@ -209,32 +209,32 @@ def test_check_waveform_callable_bad_shape_raises():
 
 
 def test_check_snr_is_none_passes():
-    snr = check_snr(None, 5)
+    snr = check_numeric_list(None, 5)
     assert snr is None
 
 
 @pytest.mark.parametrize("n_sources", [1, 5, 10])
 def test_check_snr_float_passes(n_sources):
-    snr = check_snr(1.0, n_sources)
+    snr = check_numeric_list(1.0, n_sources)
     assert snr.size == n_sources
     assert np.all(snr == 1.0)
 
 
 def test_check_snr_array_valid_shape_passes():
     initial = [1, 2, 3, 4, 5]
-    snr = check_snr(initial, 5)
+    snr = check_numeric_list(initial, 5)
     assert np.array_equal(snr, initial)
 
 
 def test_check_snr_array_invalid_shape_raises():
     initial = [1, 2, 3, 4, 5]
     with pytest.raises(ValueError, match="of the 3 sources, got 5"):
-        check_snr(initial, 3)
+        check_numeric_list(initial, 3)
 
 
 def test_check_snr_negative_snr_raises():
     with pytest.raises(ValueError, match="Each SNR value should be positive"):
-        check_snr([-1, 0, 1], 3)
+        check_numeric_list([-1, 0, 1], 3)
 
 
 def test_check_snr_params_snr_is_none():

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -86,13 +86,7 @@ def test_sourceconfiguration_to_raw(apply_forward_mock):
     raw = sc.to_raw([], [])
     apply_forward_mock.assert_called()
     stc = apply_forward_mock.call_args.args[1]
-    assert np.all(stc.data == 1e-6), "Default scaling factor was not applied correctly"
-    assert raw == 0, "Output of apply_forward_raw should not be changed"
-
-    raw = sc.to_raw([], [], scaling_factor=10)
-    apply_forward_mock.assert_called()
-    stc = apply_forward_mock.call_args.args[1]
-    assert np.all(stc.data == 10), "Custom scaling factor was not applied correctly"
+    assert np.all(stc.data == 1), "Source time courses should not be changed"
     assert raw == 0, "Output of apply_forward_raw should not be changed"
 
 

--- a/tests/test_coupling_graph.py
+++ b/tests/test_coupling_graph.py
@@ -139,7 +139,7 @@ def test_set_coupling(generate_mock):
     coupling_graph.add_edges_from(coupling)
     times = np.arange(100) / 100
 
-    sources = _set_coupling(sources, coupling_graph, times, random_state=0)
+    _set_coupling(sources, coupling_graph, times, random_state=0)
 
     # Check that the coupled waveforms were saved correctly
     # First value in the tuple is the provided argument for kappa
@@ -159,7 +159,7 @@ def test_set_coupling_random_state(generate_mock):
     times = np.arange(100) / 100
     random_state = 1234
 
-    sources = _set_coupling(sources, coupling_graph, times, random_state)
+    _set_coupling(sources, coupling_graph, times, random_state)
 
     # Check that the random state was forwarded to low-level functions
     assert generate_mock.call_args.kwargs["random_state"] == random_state

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -308,17 +308,18 @@ def test_simulate():
     # some dummy data - 2 sources + (1 + 3 = 4) noise sources expected
     source_groups = [
         PointSourceGroup(
-            2, [(0, 0), (0, 1)], np.ones((2, 100)), None, dict(), ["s2", "s3"]
+            2, [(0, 0), (0, 1)], np.ones((2, 100)), None, dict(), 1, ["s2", "s3"]
         ),
     ]
     noise_groups = [
-        PointSourceGroup(1, [(0, 0)], np.array([0]), None, dict(), ["s1"]),
+        PointSourceGroup(1, [(0, 0)], np.array([0]), None, dict(), 1, ["s1"]),
         PointSourceGroup(
             3,
             [(0, 0), (0, 1), (1, 0)],
             np.ones((3, 100)),
             None,
             dict(),
+            1,
             ["s4", "s5", "s6"],
         ),
     ]
@@ -384,11 +385,12 @@ def test_simulate_local_snr_adjustment(adjust_snr_mock):
             waveform=np.ones((1, 100)),
             snr=np.array([5.0]),
             snr_params=dict(fmin=8, fmax=12),
+            std=1,
             names=["s1"],
         ),
     ]
     noise_groups = [
-        PointSourceGroup(1, [(1, 1)], np.ones((1, 100)), None, dict(), ["n1"]),
+        PointSourceGroup(1, [(1, 1)], np.ones((1, 100)), None, dict(), 1, ["n1"]),
     ]
 
     with patch.object(
@@ -437,11 +439,12 @@ def test_simulate_global_snr_adjustment(adjust_snr_mock):
             waveform=np.ones((1, 100)),
             snr=None,
             snr_params=dict(),
+            std=1,
             names=["s1"],
         ),
     ]
     noise_groups = [
-        PointSourceGroup(1, [(1, 1)], np.ones((1, 100)), None, dict(), ["n1"]),
+        PointSourceGroup(1, [(1, 1)], np.ones((1, 100)), None, dict(), 1, ["n1"]),
     ]
 
     with patch.object(
@@ -490,6 +493,7 @@ def test_simulate_coupling_setup(set_coupling_mock):
             waveform=np.ones((2, 500)),
             snr=None,
             snr_params=dict(),
+            std=1,
             names=["s1", "s2"],
         ),
     ]

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -341,7 +341,7 @@ def test_simulate():
             src=src,
             times=times,
             fwd=None,
-            base_amplitude=1e-9,
+            base_std=1e-9,
             random_state=0,
         )
 
@@ -357,10 +357,10 @@ def test_simulate():
         assert len(sources) == 2, f"Expected 2 sources, got {len(sources)}"
         assert len(noise_sources) == 4, f"Expected 4 sources, got {len(noise_sources)}"
 
-        # Check that all source waveform were scaled by the base amplitude
+        # Check that all source waveform were scaled by the base std
         for s in sources.values():
             assert np.allclose(s.waveform, 1e-9)
-        for ns in noise_sources.values():
+        for s in noise_sources.values():
             assert np.allclose(s.waveform, 1e-9)
 
 
@@ -410,7 +410,7 @@ def test_simulate_local_snr_adjustment(adjust_snr_mock):
             src=src,
             times=times,
             fwd=fwd,
-            base_amplitude=1e-9,
+            base_std=1e-9,
             random_state=0,
         )
 
@@ -464,7 +464,7 @@ def test_simulate_global_snr_adjustment(adjust_snr_mock):
             src=src,
             times=times,
             fwd=fwd,
-            base_amplitude=1e-9,
+            base_std=1e-9,
             random_state=0,
         )
 
@@ -519,9 +519,12 @@ def test_simulate_coupling_setup(set_coupling_mock):
             src=src,
             times=times,
             fwd=fwd,
-            base_amplitude=1e-9,
+            base_std=1e-9,
             random_state=0,
         )
 
         # Check that the coupling setup was performed
         set_coupling_mock.assert_called()
+
+
+# std affects only the chosen source, not the noise ones

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -340,6 +340,7 @@ def test_simulate():
             src=src,
             times=times,
             fwd=None,
+            base_amplitude=1e-9,
             random_state=0,
         )
 
@@ -355,8 +356,14 @@ def test_simulate():
         assert len(sources) == 2, f"Expected 2 sources, got {len(sources)}"
         assert len(noise_sources) == 4, f"Expected 4 sources, got {len(noise_sources)}"
 
+        # Check that all source waveform were scaled by the base amplitude
+        for s in sources.values():
+            assert np.allclose(s.waveform, 1e-9)
+        for ns in noise_sources.values():
+            assert np.allclose(s.waveform, 1e-9)
 
-@patch("meegsim.simulate._adjust_snr_local", return_value=[])
+
+@patch("meegsim.simulate._adjust_snr_local")
 def test_simulate_local_snr_adjustment(adjust_snr_mock):
     # return mock PointSource's - 1 noise source, 1 signal source
     simulate_mock = Mock(
@@ -390,7 +397,7 @@ def test_simulate_local_snr_adjustment(adjust_snr_mock):
         sfreq = 100
         duration = 5
         times = np.arange(0, sfreq * duration) / sfreq
-        sources, _ = _simulate(
+        _simulate(
             source_groups=source_groups,
             noise_groups=noise_groups,
             coupling_graph=nx.Graph(),
@@ -401,17 +408,15 @@ def test_simulate_local_snr_adjustment(adjust_snr_mock):
             src=src,
             times=times,
             fwd=fwd,
+            base_amplitude=1e-9,
             random_state=0,
         )
 
         # Check that the SNR adjustment was performed
         adjust_snr_mock.assert_called()
 
-        # Check that the result (empty list in the mock) was saved as is
-        assert not sources
 
-
-@patch("meegsim.simulate._adjust_snr_global", return_value=[])
+@patch("meegsim.simulate._adjust_snr_global")
 def test_simulate_global_snr_adjustment(adjust_snr_mock):
     # return mock PointSource's - 1 noise source, 1 signal source
     simulate_mock = Mock(
@@ -445,7 +450,7 @@ def test_simulate_global_snr_adjustment(adjust_snr_mock):
         sfreq = 100
         duration = 5
         times = np.arange(0, sfreq * duration) / sfreq
-        sources, _ = _simulate(
+        _simulate(
             source_groups=source_groups,
             noise_groups=noise_groups,
             coupling_graph=nx.Graph(),
@@ -456,17 +461,15 @@ def test_simulate_global_snr_adjustment(adjust_snr_mock):
             src=src,
             times=times,
             fwd=fwd,
+            base_amplitude=1e-9,
             random_state=0,
         )
 
         # Check that the SNR adjustment was performed
         adjust_snr_mock.assert_called()
 
-        # Check that the result (empty list in the mock) was saved as is
-        assert not sources
 
-
-@patch("meegsim.simulate._set_coupling", return_value=[])
+@patch("meegsim.simulate._set_coupling")
 def test_simulate_coupling_setup(set_coupling_mock):
     # return 2 mock PointSource's
     simulate_mock = Mock(
@@ -501,7 +504,7 @@ def test_simulate_coupling_setup(set_coupling_mock):
         sfreq = 100
         duration = 5
         times = np.arange(0, sfreq * duration) / sfreq
-        sources, _ = _simulate(
+        _simulate(
             source_groups=source_groups,
             noise_groups=noise_groups,
             coupling_graph=coupling_graph,
@@ -512,11 +515,9 @@ def test_simulate_coupling_setup(set_coupling_mock):
             src=src,
             times=times,
             fwd=fwd,
+            base_amplitude=1e-9,
             random_state=0,
         )
 
         # Check that the coupling setup was performed
         set_coupling_mock.assert_called()
-
-        # Check that the result (empty list in the mock) was saved as is
-        assert not sources

--- a/tests/test_snr.py
+++ b/tests/test_snr.py
@@ -195,7 +195,7 @@ def test_adjust_snr_local_point(adjust_snr_mock):
     noise_sources = {"n1": prepare_point_source(name="n1")}
     tstep = 0.01
 
-    sources = _adjust_snr_local(src, fwd, tstep, sources, source_groups, noise_sources)
+    _adjust_snr_local(src, fwd, tstep, sources, source_groups, noise_sources)
 
     # Check the SNR adjustment was performed only once
     adjust_snr_mock.assert_called_once()
@@ -238,7 +238,7 @@ def test_adjust_snr_local_patch(adjust_snr_mock):
     noise_sources = {"n1": prepare_point_source(name="n1")}
     tstep = 0.01
 
-    sources = _adjust_snr_local(src, fwd, tstep, sources, source_groups, noise_sources)
+    _adjust_snr_local(src, fwd, tstep, sources, source_groups, noise_sources)
 
     # Check the SNR adjustment was performed only once
     adjust_snr_mock.assert_called_once()
@@ -276,7 +276,7 @@ def test_adjust_snr_global_point(adjust_snr_mock):
     noise_sources = {"n1": prepare_point_source(name="n1")}
     tstep = 0.01
 
-    sources = _adjust_snr_global(
+    _adjust_snr_global(
         src,
         fwd,
         snr_global=5,
@@ -308,7 +308,7 @@ def test_adjust_snr_global_patch(adjust_snr_mock):
     noise_sources = {"n1": prepare_point_source(name="n1")}
     tstep = 0.01
 
-    sources = _adjust_snr_global(
+    _adjust_snr_global(
         src,
         fwd,
         snr_global=5,

--- a/tests/test_snr.py
+++ b/tests/test_snr.py
@@ -177,6 +177,7 @@ def test_adjust_snr_local_point(adjust_snr_mock):
             waveform=np.ones((1, 100)),
             snr=np.array([5.0]),
             snr_params=dict(fmin=8, fmax=12),
+            std=1,
             names=["s1"],
         ),
         PointSourceGroup(
@@ -185,6 +186,7 @@ def test_adjust_snr_local_point(adjust_snr_mock):
             waveform=np.ones((1, 100)),
             snr=None,
             snr_params=dict(),
+            std=1,
             names=["s2"],
         ),
     ]
@@ -218,6 +220,7 @@ def test_adjust_snr_local_patch(adjust_snr_mock):
             waveform=np.ones((1, 100)),
             snr=np.array([5.0]),
             snr_params=dict(fmin=8, fmax=12),
+            std=1,
             extents=None,
             names=["s1"],
         ),
@@ -227,6 +230,7 @@ def test_adjust_snr_local_patch(adjust_snr_mock):
             waveform=np.ones((1, 100)),
             snr=None,
             snr_params=dict(),
+            std=1,
             extents=None,
             names=["s2"],
         ),

--- a/tests/test_source_groups.py
+++ b/tests/test_source_groups.py
@@ -29,7 +29,7 @@ def test_basesourcegroup_is_abstract():
 
 
 def test_pointsourcegroup_repr_no_callables():
-    point_sg = PointSourceGroup(4, [(0, 0)], np.array([0]), None, dict(), [])
+    point_sg = PointSourceGroup(4, [(0, 0)], np.array([0]), None, dict(), 1, [])
     assert "4 sources" in repr(point_sg)
     assert "location=list" in repr(point_sg)
     assert "waveform=array" in repr(point_sg)
@@ -43,7 +43,7 @@ def test_pointsourcegroup_repr_with_callables():
         return x
 
     point_sg = PointSourceGroup(
-        4, partial(my_location, x=1), partial(my_waveform, x=1), None, dict(), []
+        4, partial(my_location, x=1), partial(my_waveform, x=1), None, dict(), 1, []
     )
     assert "4 sources" in repr(point_sg)
     assert "location=my_location" in repr(point_sg)
@@ -61,6 +61,7 @@ def test_pointsourcegroup_create_using_arrays(location_mock, waveform_mock):
         location,
         waveform,
         snr=None,
+        std=1,
         location_params=dict(pick=1),
         waveform_params=dict(value=1),
         snr_params=dict(),
@@ -94,6 +95,7 @@ def test_pointsourcegroup_create_using_callables(location_mock, waveform_mock):
         location_fun,
         waveform_fun,
         snr=None,
+        std=1,
         location_params=dict(pick=1),
         waveform_params=dict(value=1),
         snr_params=dict(),

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -122,14 +122,16 @@ def test_pointsource_create_from_arrays():
     times = np.arange(n_samples) / sfreq
     location = [(0, 0), (1, 1)]
     waveform = np.tile(np.arange(n_sources), (n_samples, 1)).T
+    stds = [1, 2]
     names = ["s1", "s2"]
 
-    sources = PointSource.create(src, times, n_sources, location, waveform, names)
+    sources = PointSource.create(src, times, n_sources, location, waveform, stds, names)
 
     # Check that the inputs were distributed correctly between sources
     assert [s.src_idx for s in sources] == [0, 1]
     assert [s.vertno for s in sources] == [0, 1]
     assert [s.waveform[0] for s in sources] == [0, 1]
+    assert [s.std for s in sources] == stds
     assert [s.name for s in sources] == names
 
 
@@ -148,14 +150,16 @@ def test_pointsource_create_from_callables():
     times = np.arange(n_samples) / sfreq
     location = location_pick_first
     waveform = waveform_constant
+    stds = [1, 2]
     names = ["s1", "s2"]
 
-    sources = PointSource.create(src, times, n_sources, location, waveform, names)
+    sources = PointSource.create(src, times, n_sources, location, waveform, stds, names)
 
     # Check that the inputs were distributed correctly between sources
     assert [s.src_idx for s in sources] == [0, 1]
     assert [s.vertno for s in sources] == [0, 0]
     assert [s.waveform[0] for s in sources] == [0, 1]
+    assert [s.std for s in sources] == stds
     assert [s.name for s in sources] == names
 
 
@@ -224,7 +228,7 @@ def test_patchsource_to_stc_bad_vertno_raises():
         s.to_stc(src, tstep=0.01, subject="mysubject")
 
 
-def test_patch_source_with_extent():
+def test_patchsource_create_with_extent():
     """Test that PatchSource properly handles 'extent' parameter."""
 
     src = prepare_source_space(
@@ -251,6 +255,7 @@ def test_patch_source_with_extent():
             ),
         ]
     )  # Two waveforms for two sources
+    stds = [1, 2]
     names = ["source_1", "source_2"]
 
     # Mock extents for each source
@@ -270,6 +275,7 @@ def test_patch_source_with_extent():
             n_sources=n_sources,
             location=location,
             waveform=waveform,
+            stds=stds,
             names=names,
             extents=extents,
             random_state=None,
@@ -283,12 +289,14 @@ def test_patch_source_with_extent():
         assert source_1.name == "source_1", "First source name mismatch"
         assert source_1.src_idx == 0, "First source src_idx mismatch"
         assert source_1.vertno == vertno, "First source vertno mismatch"
+        assert source_1.std == 1, "First source std mismatch"
 
         # Check the second source (without extent)
         source_2 = sources[1]
         assert source_2.name == "source_2", "Second source name mismatch"
         assert source_2.src_idx == 1, "Second source src_idx mismatch"
         assert source_2.vertno == [8], "Second source vertno mismatch"
+        assert source_2.std == 2, "Second source std mismatch"
 
         # Verify that grow_labels was called once for the source with extent
         mock_grow_labels.assert_called_once_with("meegsim", 2, 3, 0, subjects_dir=None)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,7 +7,7 @@ from meegsim.utils import (
     _extract_hemi,
     unpack_vertices,
     combine_stcs,
-    normalize_power,
+    normalize_variance,
     get_sfreq,
     vertices_to_mne,
 )
@@ -91,13 +91,13 @@ def test_combine_stcs_overlap():
     assert np.array_equal(stc.data, expected_data)
 
 
-def test_normalize_power():
+def test_normalize_variance():
     data = np.random.randn(10, 1000)
-    normalized = normalize_power(data)
+    normalized = normalize_variance(data)
 
     # Should not change the shape but should change the norm
     assert data.shape == normalized.shape
-    assert np.allclose(np.linalg.norm(normalized, axis=1), 1)
+    assert np.allclose(np.var(normalized, axis=1), 1)
 
 
 def test_get_sfreq():


### PR DESCRIPTION
Key changes:
* divide by standard deviation of the signal instead of its norm when normalizing. With norm, the amplitude of the normalized signal depends of the length of the signal, std accounts for it
* introduce `base_amplitude` as a base unit: without any adjustments, the variance of the source is equal to `base_amplitude ** 2`. Currently it is set to 10^-9 (1 nAm) but I am open to other choices. Closes #1.
* provide an option to set `std` when defining the sources. I decided to use this term instead of amplitude to make it semantically applicable to broadband signals as well.